### PR TITLE
Tran 178 implement registration controller

### DIFF
--- a/src/auth/src/controllers/auth.ts
+++ b/src/auth/src/controllers/auth.ts
@@ -8,8 +8,9 @@ export class AuthController {
   ){}
 
   async register(request: FastifyRequest<{ Body: RegisterDto }>, reply: FastifyReply) : Promise<FastifyReply> {
-    const { name, email, password } = request.body;
-    const user: SafeUserDto = await this.authService.register({ name, email, password });
+    request.log.info({ body: request.body }, 'Registration attempt');
+    const user: SafeUserDto = await this.authService.register(request.body);
+    request.log.info({ userId: user.id }, 'User registered successfully');
     return reply.code(201).send(user);
   }
 }

--- a/test/auth/controllers/auth.register.test.ts
+++ b/test/auth/controllers/auth.register.test.ts
@@ -2,39 +2,45 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { AuthController } from '../../../src/auth/src/controllers/auth.js';
 
 
-const MockAuthService = {
-  register: vi.fn()
-};
-
-const MockReply = {
-  code: vi.fn().mockReturnThis(),
-  send: vi.fn()
-};
-
 describe('AuthController - register', () => {
-  let authController: AuthController;
+  const MockAuthService = {
+    register: vi.fn()
+  };
+
+  const MockReply = {
+    code: vi.fn().mockReturnThis(),
+    send: vi.fn()
+  };
+
+  let authController: any;
+  let mockRequest: any;
 
   beforeEach(() => {
     vi.clearAllMocks();
     authController = new AuthController(MockAuthService as any);
+    mockRequest = {
+      body: {},
+      log: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn()
+      }
+    };
   });
 
-  it ('should register a new user and return SafeUserDto', async () => {
-    const mockRequest = {
-      body: {
-        name: 'John Doe',
-        email: 'john.doe@example.com',
-        password: 'securepassword'
-      }
-    } as any;
-
+  it('should register a new user and return SafeUserDto', async () => {
+    mockRequest.body = {
+      name: 'John Doe',
+      email: 'john.doe@example.com',
+      password: 'securepassword'
+    };
     const mockUser = {
       id: 1,
       name: 'John Doe',
       email: 'john.doe@example.com'
     };
-    
     MockAuthService.register.mockResolvedValueOnce(mockUser);
+
     await authController.register(mockRequest, MockReply as any);
 
     expect(MockAuthService.register).toHaveBeenCalledWith({
@@ -42,20 +48,24 @@ describe('AuthController - register', () => {
       email: 'john.doe@example.com',
       password: 'securepassword'
     });
-
     expect(MockReply.code).toHaveBeenCalledWith(201);
     expect(MockReply.send).toHaveBeenCalledWith(mockUser);
+    expect(mockRequest.log.info).toHaveBeenCalledWith(
+      { body: mockRequest.body },
+      'Registration attempt'
+    );
+    expect(mockRequest.log.info).toHaveBeenCalledWith(
+      { userId: mockUser.id },
+      'User registered successfully'
+    );
   });
 
-  it ('Should handle errors during registration', async () => {
-    const mockRequest = {
-      body: {
-        name: 'Jane Doe',
-        email: 'jane.doe@example.com',
-        password: 'anotherpassword'
-      }
-    } as any;
-
+  it('should handle errors during registration', async () => {
+    mockRequest.body = {
+      name: 'Jane Doe',
+      email: 'jane.doe@example.com',
+      password: 'anotherpassword'
+    };
     const mockError = new Error('Registration failed');
     MockAuthService.register.mockRejectedValueOnce(mockError);
 
@@ -68,5 +78,14 @@ describe('AuthController - register', () => {
     });
     expect(MockReply.code).not.toHaveBeenCalled();
     expect(MockReply.send).not.toHaveBeenCalled();
+    expect(mockRequest.log.info).toHaveBeenCalledWith(
+      { body: mockRequest.body },
+      'Registration attempt'
+    );
+    // Should not log success
+    expect(mockRequest.log.info).not.toHaveBeenCalledWith(
+      expect.objectContaining({ userId: expect.anything() }),
+      'User registered successfully'
+    );
   });
 });


### PR DESCRIPTION
This pull request introduces a new `AuthController` for handling user registration and adds comprehensive unit tests to ensure its correct behavior. The main focus is on implementing the registration endpoint and verifying both successful and error scenarios.

**New controller and endpoint:**

* Added `AuthController` class with a `register` method that handles user registration by delegating to the `AuthService` and returns a `SafeUserDto` with a 201 status code. (`src/auth/src/controllers/auth.ts`)

**Testing improvements:**

* Added unit tests for the `AuthController.register` method, covering successful registration and error handling using mocked dependencies. (`test/auth/controllers/auth.register.test.ts`)