### PR TITLE
refactor: Rename interfaces to use 'I' prefix for consistency across …

### DIFF
--- a/src/auth/src/config/password.ts
+++ b/src/auth/src/config/password.ts
@@ -1,5 +1,5 @@
 import { PasswordLimitsConfig } from '../constants/password.js';
-import { PasswordLimitsConfigShape, PasswordPolicyConfigShape } from '../types/password.js';
+import { IPasswordLimitsConfig, IPasswordPolicyConfig } from '../types/password.js';
 import { validatePasswordLengthLimits } from '../validators/password.js';
 import { parseIntSave } from '../utils/parse-int-save.js';
 
@@ -12,7 +12,7 @@ export function getEnvSaltRounds(def: number): number {
 const minLength = parseIntSave(process.env.PASSWORD_MIN_LENGTH, PasswordLimitsConfig.DEFAULT_MIN_LENGTH);
 const maxLength = parseIntSave(process.env.PASSWORD_MAX_LENGTH, PasswordLimitsConfig.DEFAULT_MAX_LENGTH);
 
-export function createPasswordPolicyConfig(minLength: number, maxLength: number, limits: PasswordLimitsConfigShape) : Readonly<PasswordPolicyConfigShape> {
+export function createPasswordPolicyConfig(minLength: number, maxLength: number, limits: IPasswordLimitsConfig) : Readonly<IPasswordPolicyConfig> {
   validatePasswordLengthLimits(minLength, maxLength, limits);
   return {
     minLength,

--- a/src/auth/src/constants/password.ts
+++ b/src/auth/src/constants/password.ts
@@ -1,4 +1,4 @@
-import { PasswordLimitsConfigShape as Limits } from '../types/password.js';
+import { IPasswordLimitsConfig as Limits } from '../types/password.js';
 
 export const PasswordError = {
   TOO_SHORT: 'TOO_SHORT',

--- a/src/auth/src/dao/credentials.dao.ts
+++ b/src/auth/src/dao/credentials.dao.ts
@@ -1,4 +1,4 @@
-import { CredentialsDaoShape } from '../types/daos/credentials.js';
+import { ICredentialsDao } from '../types/daos/credentials.js';
 import { PrismaClient, UserCredentials } from '../../generated/prisma/client.js';
 import { CreatePasswordDto, UpdatePasswordDto, DeletePasswordDto, FindPasswordDto } from '../types/dtos/credentials.js';
 
@@ -14,7 +14,7 @@ import { CreatePasswordDto, UpdatePasswordDto, DeletePasswordDto, FindPasswordDt
  * - deleteByuser_id: Deletes a user's password record by their user ID.
  */
 
-export class CredentialsDao implements CredentialsDaoShape {
+export class CredentialsDao implements ICredentialsDao {
 
   constructor(private readonly prismaClient: PrismaClient) {}
 

--- a/src/auth/src/dao/refresh-token.dao.ts
+++ b/src/auth/src/dao/refresh-token.dao.ts
@@ -1,6 +1,6 @@
 import { PrismaClient, RefreshToken } from '../../generated/prisma/client.js';
 import { CreateRefreshTokenDto, FindRefreshTokenDto, RevokeAllDto, RevokeRefreshTokenDto } from '../types/dtos/refresh-token.js';
-import { RefreshTokenDaoShape } from '../types/daos/refresh-token.js';
+import { IRefreshTokenDao } from '../types/daos/refresh-token.js';
 
 /**
  * Data Access Object (DAO) implementation for managing refresh tokens.
@@ -13,7 +13,7 @@ import { RefreshTokenDaoShape } from '../types/daos/refresh-token.js';
  * - deleteAllRevoked: Deletes all revoked refresh tokens from the database.
  */
 
-export class RefreshTokenDao implements RefreshTokenDaoShape {
+export class RefreshTokenDao implements IRefreshTokenDao {
   constructor(
     private readonly prismaClient: PrismaClient,
     private readonly expirationMs: number

--- a/src/auth/src/services/auth.ts
+++ b/src/auth/src/services/auth.ts
@@ -1,6 +1,6 @@
 import { UserManagementService } from '../types/user-management-service.js';
-import { CredentialsDaoShape } from '../types/daos/credentials.js';
-import { RefreshTokenDaoShape } from '../types/daos/refresh-token.js';
+import { ICredentialsDao } from '../types/daos/credentials.js';
+import { IRefreshTokenDao } from '../types/daos/refresh-token.js';
 import { SafeUserDto, LoggedInUserDto, RefreshedTokensDto } from '../types/dtos/auth.js';
 import { passwordHasher, comparePasswordHash } from '../utils/password-hash.js';
 import { SaltLimits } from '../constants/password.js';
@@ -15,15 +15,15 @@ import * as SchemaTypes from '../schemas/auth.js';
  * 
  * Provides methods for user registration and authentication.
  * Utilizes UserManagementService for user operations,
- * CredentialsDaoShape for managing user credentials,
- * and RefreshTokenDaoShape for handling refresh tokens.
+ * ICredentialsDao for managing user credentials,
+ * and IRefreshTokenDao for handling refresh tokens.
  */ 
 
 export class AuthService {
   constructor(
     private readonly userService: UserManagementService,
-    private readonly credentialsDao: CredentialsDaoShape,
-    private readonly refreshTokenDao: RefreshTokenDaoShape) {}
+    private readonly credentialsDao: ICredentialsDao,
+    private readonly refreshTokenDao: IRefreshTokenDao) {}
 
 
   async register(registerDto: SchemaTypes.RegistrationSchemaType): Promise<SafeUserDto> {

--- a/src/auth/src/types/daos/credentials.ts
+++ b/src/auth/src/types/daos/credentials.ts
@@ -11,7 +11,7 @@ import { UserCredentials } from '../../../generated/prisma/client.js';
  * - findByUserId: Finds a user's password by their user ID.
  * - deleteByuser_id: Deletes a user's password record by their user ID.
  */
-export interface CredentialsDaoShape {
+export interface ICredentialsDao {
   create(data: CreatePasswordDto): Promise<void>;
   updatePassword(data: UpdatePasswordDto): Promise<void>;
   findByUserId(data: FindPasswordDto): Promise<UserCredentials | null>;

--- a/src/auth/src/types/daos/refresh-token.ts
+++ b/src/auth/src/types/daos/refresh-token.ts
@@ -11,7 +11,7 @@ import { RevokeRefreshTokenDto, CreateRefreshTokenDto, FindRefreshTokenDto, Revo
  * - deleteAllForUser: Deletes all refresh tokens associated with a specific user ID.
  * - deleteAllRevoked: Deletes all revoked refresh tokens from the database.
  */
-export interface RefreshTokenDaoShape {
+export interface IRefreshTokenDao {
   store(data: CreateRefreshTokenDto): Promise<void>;
   revoke(data: RevokeRefreshTokenDto): Promise<void>;
   revokeAllByUserId(data: RevokeAllDto): Promise<void>;

--- a/src/auth/src/types/jwt.ts
+++ b/src/auth/src/types/jwt.ts
@@ -18,7 +18,7 @@ export interface JwtConfigShape {
  * @property {string} user_email - The email address of the authenticated user. Used for user identification and notifications.
  *                         
  */
-export interface JwtPayLoadShape {
+export interface IJwtPayLoad {
   sub: number;
   user_email: string;
 };
@@ -26,17 +26,17 @@ export interface JwtPayLoadShape {
 /**
  * A decoded JWT access token with all standard registered claims.
  * 
- * This interface extends JwtPayLoadShape with the standard JWT claims that are
+ * This interface extends IJwtPayLoad with the standard JWT claims that are
  * automatically added by the jwt library during token creation and verification.
  * 
- * @extends {JwtPayLoadShape}
+ * @extends {IJwtPayLoad}
  * @property {number} iat - Issued At claim. Unix timestamp (seconds) when the token was created.
  * @property {number} exp - Expiration Time claim. Unix timestamp (seconds) when the token expires.
  * @property {string} iss - Issuer claim. Identifies the principal that issued the token (set to JWT_ISSUER constant).
  * @property {string} aud - Audience claim. Identifies the intended recipient of the token (set to JWT_AUDIENCE constant).
  * @property {number} [nbf] - Optional. Not Before claim. Unix timestamp (seconds) before which the token is not valid.
  */
-export interface DecodedJwtPayload extends JwtPayLoadShape {
+export interface DecodedJwtPayload extends IJwtPayLoad {
   iat: number;
   exp: number;
   iss: string;

--- a/src/auth/src/types/password.ts
+++ b/src/auth/src/types/password.ts
@@ -1,12 +1,12 @@
 import { PasswordErrorCode } from '../constants/password.js';
 
-export interface PasswordValidationResultShape  {
+export interface IPasswordValidationResult  {
   valid: boolean;
   errors: PasswordErrorCode[]; 
   messages: string[];
 }
 
-export interface PasswordPolicyConfigShape{
+export interface IPasswordPolicyConfig {
   minLength: number;
   maxLength: number;
   requiredUppercase: boolean;
@@ -16,7 +16,7 @@ export interface PasswordPolicyConfigShape{
   allowSpaces: boolean;
 }
 
-export interface PasswordLimitsConfigShape {
+export interface IPasswordLimitsConfig {
   MIN_LENGTH_LOWER_BOUND: number;
   MIN_LENGTH_UPPER_BOUND: number;
   MAX_LENGTH_LOWER_BOUND: number;

--- a/src/auth/src/types/security.ts
+++ b/src/auth/src/types/security.ts
@@ -1,5 +1,5 @@
 //** Configuration defining the limits for salt values used in password hashing. */
-export interface SaltLimitsShape {
+export interface ISaltLimits {
   MIN_SALT_LENGTH: number;
   MAX_SALT_LENGTH: number;
   DEFAULT_SALT_LENGTH: number;

--- a/src/auth/src/utils/jwt.ts
+++ b/src/auth/src/utils/jwt.ts
@@ -1,5 +1,5 @@
 import { default as jwt } from 'jsonwebtoken';
-import { JwtPayLoadShape, DecodedJwtPayload } from '../types/jwt.js';
+import { IJwtPayLoad, DecodedJwtPayload } from '../types/jwt.js';
 import { GeneratedRefreshTokenDto } from '../types/dtos/refresh-token.js';
 import { getJwtConfig } from '../config/jwt.js';
 import { CryptoErrorMessage, REFRESH_TOKEN_SIZE, UUID_V4_REGEX } from '../constants/jwt.js';
@@ -14,7 +14,7 @@ import { randomBytes, createHash, timingSafeEqual, randomUUID } from 'crypto';
  * @throws {JsonWebTokenError} If the private key is invalid or signing fails
  * @throws {Error} If JWT configuration cannot be loaded
  */
-export function generateAccessToken(payload: JwtPayLoadShape): string {
+export function generateAccessToken(payload: IJwtPayLoad): string {
   const config = getJwtConfig();
   const token = jwt.sign(payload,
     config.privateKey, {

--- a/src/auth/src/utils/password-error-message.ts
+++ b/src/auth/src/utils/password-error-message.ts
@@ -1,10 +1,10 @@
 import { PasswordError, PasswordErrorCode } from '../constants/password.js';
-import { PasswordPolicyConfigShape } from '../types/password.js';
+import { IPasswordPolicyConfig } from '../types/password.js';
 
 
 export function getPasswordErrorMessage(
   errorCode: PasswordErrorCode,
-  policy: PasswordPolicyConfigShape
+  policy: IPasswordPolicyConfig
 ) : string {
 
   const messages: Record<PasswordErrorCode, string> = {

--- a/src/auth/src/utils/password-hash.ts
+++ b/src/auth/src/utils/password-hash.ts
@@ -1,9 +1,9 @@
 import bcrypt from 'bcryptjs';
 import { getEnvSaltRounds } from '../config/password.js';
-import { SaltLimitsShape } from '../types/security.js';
+import { ISaltLimits } from '../types/security.js';
 import { validateSaltLengthLimits } from '../validators/hash.js';
 
-export async function passwordHasher(password: string, saltLimits: SaltLimitsShape): Promise<string> {
+export async function passwordHasher(password: string, saltLimits: ISaltLimits): Promise<string> {
   if (!password) {
     throw new Error('Input password is required');
   }

--- a/src/auth/src/validators/hash.ts
+++ b/src/auth/src/validators/hash.ts
@@ -1,6 +1,6 @@
-import { SaltLimitsShape } from '../types/security.js';
+import { ISaltLimits } from '../types/security.js';
 
-export function validateSaltLengthLimits(saltRounds: number, saltLimits: SaltLimitsShape) : void {
+export function validateSaltLengthLimits(saltRounds: number, saltLimits: ISaltLimits) : void {
   if (isNaN(saltRounds)) {
     throw new Error(`BCRYPT_SALT_ROUNDS is not a valid intiger: got ${saltRounds}`);
   }

--- a/src/auth/src/validators/password.ts
+++ b/src/auth/src/validators/password.ts
@@ -1,56 +1,56 @@
 import { PasswordError, PasswordErrorCode } from '../constants/password.js';
-import { PasswordPolicyConfigShape, PasswordValidationResultShape, PasswordLimitsConfigShape } from '../types/password.js';
+import { IPasswordPolicyConfig, IPasswordValidationResult, IPasswordLimitsConfig } from '../types/password.js';
 import { getPasswordErrorMessage } from '../utils/password-error-message.js';
 
 
-export function checkLowercase(password: string, policy: PasswordPolicyConfigShape) : PasswordErrorCode | null {
+export function checkLowercase(password: string, policy: IPasswordPolicyConfig) : PasswordErrorCode | null {
   if (policy.requiredLowercase && !/[a-z]/.test(password))
     return PasswordError.NO_LOWERCASE;
   return null;
 }
 
 
-export function checkUppercase(password: string, policy: PasswordPolicyConfigShape) : PasswordErrorCode | null {
+export function checkUppercase(password: string, policy: IPasswordPolicyConfig) : PasswordErrorCode | null {
   if (policy.requiredUppercase && !/[A-Z]/.test(password))
     return PasswordError.NO_UPPERCASE;
   return null;
 }
 
 
-export function checkMaxLength(password: string, policy: PasswordPolicyConfigShape) : PasswordErrorCode | null {
+export function checkMaxLength(password: string, policy: IPasswordPolicyConfig) : PasswordErrorCode | null {
   return(password.length > policy.maxLength  ?  PasswordError.TOO_LONG : null);
 }
 
 
-export function checkMinLength(password: string, policy: PasswordPolicyConfigShape) : PasswordErrorCode | null {
+export function checkMinLength(password: string, policy: IPasswordPolicyConfig) : PasswordErrorCode | null {
   return(password.length < policy.minLength  ?  PasswordError.TOO_SHORT : null);
 }
 
 
-export function checkNumber(password: string, policy: PasswordPolicyConfigShape) : PasswordErrorCode | null {
+export function checkNumber(password: string, policy: IPasswordPolicyConfig) : PasswordErrorCode | null {
   if (policy.requiredNumber && !/[0-9]/.test(password))
     return (PasswordError.NO_NUMBER);
   return null;
 }
 
 
-export function checkSpace(password: string, policy: PasswordPolicyConfigShape) : PasswordErrorCode | null {
+export function checkSpace(password: string, policy: IPasswordPolicyConfig) : PasswordErrorCode | null {
   if (!policy.allowSpaces && /\s/.test(password))
     return PasswordError.HAS_SPACE;
   return null;
 }
 
 
-export function checkSpecialChar(password: string, policy: PasswordPolicyConfigShape) : PasswordErrorCode | null {
+export function checkSpecialChar(password: string, policy: IPasswordPolicyConfig) : PasswordErrorCode | null {
   if (policy.requiredSpecialChar && !/[!@#$%^&*(),.?":{}|<>]/.test(password))
     return PasswordError.NO_SPECIAL;
   return null;
 }
 
 
-export function validatePassword(password: string, policy: PasswordPolicyConfigShape) : PasswordValidationResultShape {
+export function validatePassword(password: string, policy: IPasswordPolicyConfig) : IPasswordValidationResult {
 
-  type PasswordRules = (password: string, policy: PasswordPolicyConfigShape) => PasswordErrorCode | null;
+  type PasswordRules = (password: string, policy: IPasswordPolicyConfig) => PasswordErrorCode | null;
 
   const rules : PasswordRules[] = [
     checkLowercase,
@@ -78,7 +78,7 @@ export function validatePassword(password: string, policy: PasswordPolicyConfigS
 }
 
 
-export function validatePasswordLengthLimits(minLength: number, maxLength:number, passwordLimits: PasswordLimitsConfigShape) : void {
+export function validatePasswordLengthLimits(minLength: number, maxLength:number, passwordLimits: IPasswordLimitsConfig) : void {
 
   if (isNaN(minLength)) {
     throw new Error(`PASSWORD_MIN_LENGTH is not a valid intiger: got ${minLength}`);

--- a/test/auth/dao/credentials.dao.test.ts
+++ b/test/auth/dao/credentials.dao.test.ts
@@ -1,5 +1,5 @@
 import { CredentialsDao } from '../../../src/auth/src/dao/credentials.dao.js';
-import { CredentialsDaoShape } from '../../../src/auth/src/types/daos/credentials.js';
+import { ICredentialsDao } from '../../../src/auth/src/types/daos/credentials.js';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 
@@ -13,7 +13,7 @@ const mockPrismaClient = {
 };
 
 describe('CredentialsDao', () => {
-  let dao: CredentialsDaoShape;
+  let dao: ICredentialsDao;
   beforeEach(() => {
     vi.clearAllMocks();
     dao = new CredentialsDao(mockPrismaClient as any);

--- a/test/auth/dao/refresh-token.dao.test.ts
+++ b/test/auth/dao/refresh-token.dao.test.ts
@@ -1,5 +1,5 @@
 import { RefreshTokenDao } from '../../../src/auth/src/dao/refresh-token.dao.js';
-import { RefreshTokenDaoShape } from '../../../src/auth/src/types/daos/refresh-token.js';
+import { IRefreshTokenDao } from '../../../src/auth/src/types/daos/refresh-token.js';
 import { CreateRefreshTokenDto } from '../../../src/auth/src/types/dtos/refresh-token.js';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
@@ -13,7 +13,7 @@ const mockPrismaClient = {
 };
 
 describe('RefreshTokenSessionDao', () => {
-  let dao: RefreshTokenDaoShape;
+  let dao: IRefreshTokenDao;
   beforeEach(() => {
     vi.clearAllMocks();
     dao = new RefreshTokenDao(mockPrismaClient as any, 7 * 24 * 60 * 60 * 1000); // 7 days in ms

--- a/test/auth/hash/get-salt-env.test.ts
+++ b/test/auth/hash/get-salt-env.test.ts
@@ -1,4 +1,4 @@
-import { SaltLimitsShape } from '../../../src/auth/src/types/security.js';
+import { ISaltLimits } from '../../../src/auth/src/types/security.js';
 import { getEnvSaltRounds } from '../../../src/auth/src/config/password.js';
 import { describe, it, expect, beforeEach, afterAll } from 'vitest';
 
@@ -13,7 +13,7 @@ describe('getEnvSaltRounds function', () => {
     process.env = originalEnv;
   });
 
-  const SaltLimits : SaltLimitsShape = {
+  const SaltLimits : ISaltLimits = {
     MIN_SALT_LENGTH: 4,
     MAX_SALT_LENGTH: 18,
     DEFAULT_SALT_LENGTH: 12

--- a/test/auth/password/length-limits.test.ts
+++ b/test/auth/password/length-limits.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { createPasswordPolicyConfig } from '../../../src/auth/src/config/password.js';
-import type { PasswordLimitsConfigShape } from '../../../src/auth/src/types/password.js';
+import type { IPasswordLimitsConfig } from '../../../src/auth/src/types/password.js';
 
 describe('Password Length Limits Validator', () => {
-  const limits: PasswordLimitsConfigShape = {
+  const limits: IPasswordLimitsConfig = {
     MIN_LENGTH_LOWER_BOUND: 6,
     MIN_LENGTH_UPPER_BOUND: 64,
     MAX_LENGTH_LOWER_BOUND: 12,
@@ -97,7 +97,7 @@ describe('Password Length Limits Validator', () => {
 
   describe('Custom constraints', () => {
     it('should work with different constraint bounds', () => {
-      const customLimits: PasswordLimitsConfigShape = {
+      const customLimits: IPasswordLimitsConfig = {
         MIN_LENGTH_LOWER_BOUND: 1,
         MIN_LENGTH_UPPER_BOUND: 20,
         MAX_LENGTH_LOWER_BOUND: 10,
@@ -112,7 +112,7 @@ describe('Password Length Limits Validator', () => {
     });
 
     it('should reject values outside custom bounds', () => {
-      const customLimits: PasswordLimitsConfigShape = {
+      const customLimits: IPasswordLimitsConfig = {
         MIN_LENGTH_LOWER_BOUND: 10,
         MIN_LENGTH_UPPER_BOUND: 20,
         MAX_LENGTH_LOWER_BOUND: 30,

--- a/test/auth/password/validator.test.ts
+++ b/test/auth/password/validator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { PasswordPolicyConfigShape } from '../../../src/auth/src/types/password.js';
+import { IPasswordPolicyConfig } from '../../../src/auth/src/types/password.js';
 import {
   checkLowercase,
   checkNumber,
@@ -13,7 +13,7 @@ import {
 
 
 describe('validatePassword', () => {
-  const strictPolicy: PasswordPolicyConfigShape = {
+  const strictPolicy: IPasswordPolicyConfig = {
     minLength: 8,
     maxLength: 30,
     requiredUppercase: true,
@@ -23,7 +23,7 @@ describe('validatePassword', () => {
     allowSpaces: false
   };
 
-  const lenientPolicy: PasswordPolicyConfigShape = {
+  const lenientPolicy: IPasswordPolicyConfig = {
     minLength: 4,
     maxLength: 50,
     requiredUppercase: false,

--- a/test/auth/utils/parse-int-save.test.ts
+++ b/test/auth/utils/parse-int-save.test.ts
@@ -1,5 +1,5 @@
 import { describe, it , expect } from 'vitest';
-import { PasswordLimitsConfigShape } from '../../../src/auth/src/types/password';
+import { IPasswordLimitsConfig } from '../../../src/auth/src/types/password';
 import { parseIntSave } from '../../../src/auth/src/utils/parse-int-save';
 
 
@@ -7,7 +7,7 @@ import { parseIntSave } from '../../../src/auth/src/utils/parse-int-save';
 describe('Save int cast testing', () => {
 
 
-  const PasswordPolicyLimits : PasswordLimitsConfigShape = {
+  const PasswordPolicyLimits : IPasswordLimitsConfig = {
     MIN_LENGTH_LOWER_BOUND: 1,
     MIN_LENGTH_UPPER_BOUND: 64,
     MAX_LENGTH_LOWER_BOUND: 8,


### PR DESCRIPTION
Renamed interfaces to use prefix "I" instead of postfix "Shape" to increase readability and follow conventional naming standards.