### PR TITLE
Implement websockets handling in API gateway

### DIFF
--- a/src/api-gateway/src/index.ts
+++ b/src/api-gateway/src/index.ts
@@ -4,6 +4,8 @@ import helmet from '@fastify/helmet';
 import websocket from '@fastify/websocket';
 import { proxyRoutes } from './routes/proxy';
 import { healthRoutes } from './routes/health';
+import { internalRoutes } from './routes/internal';
+import { websocketRoutes } from './websocket/handler';
 import { helmetConfig, corsConfig, getBodyLimit, logSecurityConfig } from './config/security';
 import { config } from './config';
 import { loggerOptions } from './config/logger';
@@ -32,6 +34,12 @@ export const createServer = async () => {
 
   // Register health check routes (/health and /health/detailed)
   await healthRoutes(server);
+
+  // Register WebSocket routes (/ws)
+  await websocketRoutes(server);
+
+  // Register internal routes (/internal/ws/notify)
+  await internalRoutes(server);
 
   // Register all service proxy routes from configuration
   await proxyRoutes(server);

--- a/src/api-gateway/src/routes/internal.ts
+++ b/src/api-gateway/src/routes/internal.ts
@@ -1,0 +1,29 @@
+import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import { sendToUsers } from '../websocket/connections';
+
+interface NotifyBody {
+  userIds: string[];
+  event: {
+    type: string;
+    [key: string]: unknown;
+  };
+}
+
+export async function internalRoutes(server: FastifyInstance): Promise<void> {
+  server.post('/internal/ws/notify', async (request: FastifyRequest, reply: FastifyReply) => {
+    const { userIds, event } = request.body as NotifyBody;
+
+    if (!Array.isArray(userIds) || userIds.length === 0) {
+      return reply.code(400).send({ error: 'userIds must be a non-empty array' });
+    }
+
+    if (!event || typeof event.type !== 'string') {
+      return reply.code(400).send({ error: 'event must have a type field' });
+    }
+
+    const results = sendToUsers(userIds, event);
+    request.log.info({ eventType: event.type, results }, 'WebSocket notify');
+
+    return reply.send({ results });
+  });
+}

--- a/src/api-gateway/src/websocket/connections.ts
+++ b/src/api-gateway/src/websocket/connections.ts
@@ -1,0 +1,50 @@
+import type { SocketStream } from '@fastify/websocket';
+
+const connections = new Map<string, Set<SocketStream>>();
+
+export function addConnection(userId: string, connection: SocketStream): void {
+  const userConnections = connections.get(userId);
+  if (userConnections) {
+    userConnections.add(connection);
+  } else {
+    connections.set(userId, new Set([connection]));
+  }
+}
+
+export function removeConnection(userId: string, connection: SocketStream): void {
+  const userConnections = connections.get(userId);
+  if (!userConnections) return;
+
+  userConnections.delete(connection);
+  if (userConnections.size === 0) {
+    connections.delete(userId);
+  }
+}
+
+export function sendToUser(userId: string, event: object): boolean {
+  const userConnections = connections.get(userId);
+  if (!userConnections || userConnections.size === 0) return false;
+
+  const message = JSON.stringify(event);
+  for (const connection of userConnections) {
+    if (connection.socket.readyState === connection.socket.OPEN) {
+      connection.socket.send(message);
+    }
+  }
+  return true;
+}
+
+export function sendToUsers(userIds: string[], event: object): { userId: string; delivered: boolean }[] {
+  return userIds.map(userId => ({
+    userId,
+    delivered: sendToUser(userId, event)
+  }));
+}
+
+export function getConnectionCount(): number {
+  let count = 0;
+  for (const conns of connections.values()) {
+    count += conns.size;
+  }
+  return count;
+}

--- a/src/api-gateway/src/websocket/handler.ts
+++ b/src/api-gateway/src/websocket/handler.ts
@@ -1,0 +1,60 @@
+import { FastifyInstance } from 'fastify';
+import { verifyToken } from '../middleware/auth';
+import { addConnection, removeConnection } from './connections';
+
+const AUTH_TIMEOUT_MS = 5000;
+
+export async function websocketRoutes(server: FastifyInstance): Promise<void> {
+  server.get('/ws', { websocket: true }, (connection, request) => {
+    let authenticated = false;
+    let userId: string;
+
+    const timeout = setTimeout(() => {
+      if (!authenticated) {
+        request.log.warn('WebSocket auth timeout');
+        connection.socket.close(4001, 'Authentication timeout');
+      }
+    }, AUTH_TIMEOUT_MS);
+
+    connection.socket.on('message', (raw: Buffer) => {
+      if (!authenticated) {
+        try {
+          const message = JSON.parse(raw.toString());
+          if (message.type !== 'AUTH' || !message.token) {
+            connection.socket.close(4002, 'Expected AUTH message with token');
+            clearTimeout(timeout);
+            return;
+          }
+
+          const payload = verifyToken(message.token, request);
+          if (!payload) {
+            connection.socket.close(4003, 'Invalid token');
+            clearTimeout(timeout);
+            return;
+          }
+
+          authenticated = true;
+          userId = payload.sub;
+          clearTimeout(timeout);
+          addConnection(userId, connection);
+          request.log.info({ userId }, 'WebSocket authenticated');
+          connection.socket.send(JSON.stringify({ type: 'AUTH_OK' }));
+        } catch {
+          connection.socket.close(4002, 'Invalid message format');
+          clearTimeout(timeout);
+        }
+        return;
+      }
+
+      // Future: handle client-to-server messages here
+    });
+
+    connection.socket.on('close', () => {
+      clearTimeout(timeout);
+      if (authenticated) {
+        removeConnection(userId, connection);
+        request.log.info({ userId }, 'WebSocket disconnected');
+      }
+    });
+  });
+}


### PR DESCRIPTION
We gonna have one connection per client with API Gateway, services internally will notify Gateway about the event, event getting forward to the respective user.

We can now integrate other services by sending POST /internal/ws/notify with { userIds: [...], event: { type: "...", ... } }.