### PR TITLE
Update the ack flow in chat service

### DIFF
--- a/src/chat/prisma/schema.prisma
+++ b/src/chat/prisma/schema.prisma
@@ -50,7 +50,6 @@ model Message {
 
 enum ChannelType {
   DM
-  GAME_SESSION
   TOURNAMENT
   GROUP
 }

--- a/src/chat/src/routes/internal.ts
+++ b/src/chat/src/routes/internal.ts
@@ -2,7 +2,6 @@ import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { ChatService, ChatError } from '../services/chat.js';
 import type {
   SendMatchAckRequest,
-  CreateGameSessionChannelRequest,
   CreateTournamentChannelRequest,
   SystemMessageRequest
 } from '../types/chat.js';
@@ -32,25 +31,6 @@ export async function registerInternalRoutes(
         body.expiresAt
       );
       return reply.status(201).send(result);
-    } catch (error) {
-      return handleError(request, reply, error);
-    }
-  });
-
-  /**
-   * POST /chat/internal/channels/game-session
-   * Called by game service when a match starts.
-   */
-  server.post('/chat/internal/channels/game-session', async (request: FastifyRequest, reply: FastifyReply) => {
-    const body = request.body as CreateGameSessionChannelRequest;
-
-    if (!Array.isArray(body.playerIds) || !body.gameSessionId) {
-      return reply.status(400).send({ error: 'playerIds and gameSessionId are required' });
-    }
-
-    try {
-      const channel = await chatService.createGameSessionChannel(body.playerIds, body.gameSessionId);
-      return reply.status(201).send(channel);
     } catch (error) {
       return handleError(request, reply, error);
     }

--- a/src/chat/src/services/chat.ts
+++ b/src/chat/src/services/chat.ts
@@ -184,38 +184,48 @@ export class ChatService {
     if (uniqueIds.length !== 2) {
       throw new ChatError(400, 'sendMatchAck requires exactly 2 unique player IDs');
     }
+    const [playerA, playerB] = uniqueIds as [number, number];
 
-    // Create the game session channel for the matched pair
-    const channel = await this.channelDao.create({
-      type: 'GAME_SESSION',
-      name: `Match ${matchId}`,
-      memberIds: uniqueIds
-    });
-
-    // Post a MATCH_ACK message for each player
-    const messages = [];
-    for (const playerId of uniqueIds) {
-      const opponentId = uniqueIds.find(id => id !== playerId) as number;
-      const metadata: MatchAckMetadata = {
-        matchId,
-        gameMode,
-        opponentId,
-        expiresAt,
-        status: 'pending'
-      };
-
-      const message = await this.messageDao.create({
-        channelId: channel.id,
-        senderId: 0,
-        content: `Match found! Game mode: ${gameMode}. Please acknowledge to start.`,
-        type: 'SYSTEM',
-        metadata: JSON.stringify(metadata)
+    // Find or create DM between the two matched players.
+    // Block checks are intentionally skipped here — matchmaking should
+    // prevent blocked users from being paired, but we don't gate on it at
+    // the chat layer for system-initiated acks.
+    let channel = await this.channelDao.findDMBetweenUsers(playerA, playerB);
+    if (!channel) {
+      channel = await this.channelDao.create({
+        type: 'DM',
+        memberIds: [playerA, playerB]
       });
-      messages.push(message);
+      await this.notificationService.notifyUsers([playerA, playerB], {
+        type: 'chat:channel_created',
+        channel: {
+          id: channel.id,
+          type: channel.type,
+          name: channel.name,
+          members: [playerA, playerB]
+        }
+      });
     }
 
-    // Notify both players
-    await this.notificationService.notifyUsers(uniqueIds, {
+    // One shared ack message — both players respond to the same message.
+    const metadata: MatchAckMetadata = {
+      matchId,
+      gameMode,
+      playerIds: [playerA, playerB],
+      acknowledgedBy: [],
+      expiresAt,
+      status: 'pending'
+    };
+
+    const message = await this.messageDao.create({
+      channelId: channel.id,
+      senderId: 0,
+      content: `Match found! Game mode: ${gameMode}. Both players must acknowledge to start.`,
+      type: 'SYSTEM',
+      metadata: JSON.stringify(metadata)
+    });
+
+    await this.notificationService.notifyUsers([playerA, playerB], {
       type: 'chat:match_ack_required',
       channelId: channel.id,
       matchId,
@@ -223,7 +233,7 @@ export class ChatService {
       expiresAt
     });
 
-    return { channel, messages };
+    return { channel, message };
   }
 
   async respondToMatchAck(messageId: string, playerId: number, acknowledge: boolean) {
@@ -234,17 +244,12 @@ export class ChatService {
     const metadata: MatchAckMetadata = JSON.parse(message.metadata);
     if (!metadata.matchId) throw new ChatError(400, 'Not a match acknowledgement message');
 
-    // The ack message is addressed to the opponent of the sender — verify the caller is authorized
-    if (metadata.opponentId === playerId) {
-      throw new ChatError(403, 'This acknowledgement is not addressed to you');
+    if (!metadata.playerIds.includes(playerId)) {
+      throw new ChatError(403, 'You are not part of this match');
     }
 
-    // Verify caller is a member of the channel
-    const isMember = await this.channelDao.isMember(message.channelId, playerId);
-    if (!isMember) throw new ChatError(403, 'Not a member of this channel');
-
     if (metadata.status !== 'pending') {
-      throw new ChatError(400, `Acknowledgement already ${metadata.status}`);
+      throw new ChatError(400, `Match already ${metadata.status}`);
     }
 
     if (new Date(metadata.expiresAt) < new Date()) {
@@ -253,29 +258,40 @@ export class ChatService {
       throw new ChatError(410, 'Match acknowledgement has expired');
     }
 
-    metadata.status = acknowledge ? 'acknowledged' : 'expired';
+    if (metadata.acknowledgedBy.includes(playerId)) {
+      throw new ChatError(409, 'You have already responded to this match');
+    }
+
+    if (!acknowledge) {
+      metadata.status = 'declined';
+      await this.messageDao.updateMetadata(messageId, JSON.stringify(metadata));
+      await this.notificationService.notifyUsers(metadata.playerIds, {
+        type: 'chat:match_ack_response',
+        matchId: metadata.matchId,
+        playerId,
+        acknowledged: false
+      });
+      return { acknowledged: false, matchId: metadata.matchId, gameMode: metadata.gameMode };
+    }
+
+    metadata.acknowledgedBy.push(playerId);
+    const bothAcked = metadata.acknowledgedBy.length === metadata.playerIds.length;
+    if (bothAcked) metadata.status = 'acknowledged';
+
     await this.messageDao.updateMetadata(messageId, JSON.stringify(metadata));
 
-    // Notify the opponent about the ack response
-    await this.notificationService.notifyUsers([metadata.opponentId], {
+    await this.notificationService.notifyUsers(metadata.playerIds, {
       type: 'chat:match_ack_response',
       matchId: metadata.matchId,
       playerId,
-      acknowledged: acknowledge
+      acknowledged: true,
+      bothAcked
     });
 
-    return { acknowledged: acknowledge, matchId: metadata.matchId, gameMode: metadata.gameMode };
+    return { acknowledged: true, matchId: metadata.matchId, gameMode: metadata.gameMode, bothAcked };
   }
 
   // ── Internal / System ─────────────────────────────────────
-
-  async createGameSessionChannel(playerIds: number[], gameSessionId: string) {
-    return this.channelDao.create({
-      type: 'GAME_SESSION',
-      name: `Game ${gameSessionId}`,
-      memberIds: playerIds
-    });
-  }
 
   async createTournamentChannel(userId: number, tournamentId: number, tournamentName: string) {
     const channelName = `Tournament #${tournamentId}: ${tournamentName}`;

--- a/src/chat/src/types/chat.ts
+++ b/src/chat/src/types/chat.ts
@@ -21,9 +21,10 @@ export interface SendMessageRequest {
 export interface MatchAckMetadata {
   matchId: string;
   gameMode: string;
-  opponentId: number;
+  playerIds: [number, number];
+  acknowledgedBy: number[];
   expiresAt: string;
-  status: 'pending' | 'acknowledged' | 'expired';
+  status: 'pending' | 'acknowledged' | 'declined' | 'expired';
 }
 
 export interface RespondToMatchAckRequest {
@@ -33,11 +34,6 @@ export interface RespondToMatchAckRequest {
 export interface PaginationQuery {
   cursor?: string;
   limit?: number;
-}
-
-export interface CreateGameSessionChannelRequest {
-  playerIds: number[];
-  gameSessionId: string;
 }
 
 export interface CreateTournamentChannelRequest {

--- a/src/chat/test/routes/internal.test.ts
+++ b/src/chat/test/routes/internal.test.ts
@@ -10,7 +10,6 @@ describe('Internal Routes', () => {
     server = Fastify();
     mockChatService = {
       sendMatchAck: vi.fn(),
-      createGameSessionChannel: vi.fn(),
       createTournamentChannel: vi.fn(),
       sendSystemMessage: vi.fn(),
     };
@@ -26,10 +25,10 @@ describe('Internal Routes', () => {
   // ── POST /chat/internal/match-ack ───────────────────────
 
   describe('POST /chat/internal/match-ack', () => {
-    it('should create match ack channel and messages', async () => {
+    it('should create match ack in DM and return channel + message', async () => {
       const mockResult = {
-        channel: { id: 'gs-1' },
-        messages: [{ id: 'ack-1' }, { id: 'ack-2' }],
+        channel: { id: 'dm-1' },
+        message: { id: 'ack-1' },
       };
       mockChatService.sendMatchAck.mockResolvedValueOnce(mockResult);
 
@@ -55,34 +54,6 @@ describe('Internal Routes', () => {
         method: 'POST',
         url: '/chat/internal/match-ack',
         payload: { matchId: 'match-1' },
-      });
-
-      expect(response.statusCode).toBe(400);
-    });
-  });
-
-  // ── POST /chat/internal/channels/game-session ───────────
-
-  describe('POST /chat/internal/channels/game-session', () => {
-    it('should create a game session channel', async () => {
-      const mockChannel = { id: 'gs-1', type: 'GAME_SESSION' };
-      mockChatService.createGameSessionChannel.mockResolvedValueOnce(mockChannel);
-
-      const response = await server.inject({
-        method: 'POST',
-        url: '/chat/internal/channels/game-session',
-        payload: { playerIds: [1, 2], gameSessionId: 'game-abc' },
-      });
-
-      expect(response.statusCode).toBe(201);
-      expect(mockChatService.createGameSessionChannel).toBeCalledWith([1, 2], 'game-abc');
-    });
-
-    it('should return 400 without playerIds', async () => {
-      const response = await server.inject({
-        method: 'POST',
-        url: '/chat/internal/channels/game-session',
-        payload: { gameSessionId: 'game-abc' },
       });
 
       expect(response.statusCode).toBe(400);

--- a/src/chat/test/services/chat.test.ts
+++ b/src/chat/test/services/chat.test.ts
@@ -427,52 +427,55 @@ describe('ChatService', () => {
   // ── sendMatchAck ────────────────────────────────────────
 
   describe('sendMatchAck', () => {
-    it('should create game session channel and ack messages for both players', async () => {
-      const mockChannel = {
-        id: 'gs-1',
-        type: 'GAME_SESSION',
-        name: 'Match match-123',
-        members: [{ userId: 1 }, { userId: 2 }],
-      };
+    it('should create a DM and post one shared ack message when no DM exists', async () => {
+      mockChannelDao.findDMBetweenUsers.mockResolvedValueOnce(null);
+      const mockChannel = { id: 'dm-1', type: 'DM', name: null, members: [{ userId: 1 }, { userId: 2 }] };
       mockChannelDao.create.mockResolvedValueOnce(mockChannel);
-      mockMessageDao.create
-        .mockResolvedValueOnce({ id: 'ack-msg-1', senderId: 0, type: 'SYSTEM', createdAt: new Date('2026-01-01') })
-        .mockResolvedValueOnce({ id: 'ack-msg-2', senderId: 0, type: 'SYSTEM', createdAt: new Date('2026-01-01') });
+      const mockMessage = { id: 'ack-1', senderId: 0, type: 'SYSTEM', createdAt: new Date('2026-01-01') };
+      mockMessageDao.create.mockResolvedValueOnce(mockMessage);
 
       const result = await service.sendMatchAck('match-123', [1, 2], 'classic', '2026-01-01T12:05:00Z');
 
-      expect(mockChannelDao.create).toBeCalledWith({
-        type: 'GAME_SESSION',
-        name: 'Match match-123',
-        memberIds: [1, 2],
-      });
-      expect(mockMessageDao.create).toBeCalledTimes(2);
+      expect(mockChannelDao.findDMBetweenUsers).toBeCalledWith(1, 2);
+      expect(mockChannelDao.create).toBeCalledWith({ type: 'DM', memberIds: [1, 2] });
+      expect(mockMessageDao.create).toBeCalledTimes(1);
       expect(mockNotificationService.notifyUsers).toBeCalledWith([1, 2], expect.objectContaining({
         type: 'chat:match_ack_required',
         matchId: 'match-123',
         gameMode: 'classic',
       }));
       expect(result.channel).toEqual(mockChannel);
-      expect(result.messages).toHaveLength(2);
+      expect(result.message).toEqual(mockMessage);
     });
 
-    it('should set correct opponent IDs in metadata', async () => {
-      mockChannelDao.create.mockResolvedValueOnce({
-        id: 'gs-1', type: 'GAME_SESSION', members: [],
-      });
-      mockMessageDao.create
-        .mockResolvedValueOnce({ id: 'ack-1', createdAt: new Date() })
-        .mockResolvedValueOnce({ id: 'ack-2', createdAt: new Date() });
+    it('should reuse existing DM without creating a new channel', async () => {
+      const existingDM = { id: 'dm-existing', type: 'DM', members: [{ userId: 1 }, { userId: 2 }] };
+      mockChannelDao.findDMBetweenUsers.mockResolvedValueOnce(existingDM);
+      mockMessageDao.create.mockResolvedValueOnce({ id: 'ack-1', createdAt: new Date() });
+
+      const result = await service.sendMatchAck('match-456', [1, 2], 'powerup', '2026-01-01T12:05:00Z');
+
+      expect(mockChannelDao.create).not.toBeCalled();
+      expect(result.channel).toEqual(existingDM);
+    });
+
+    it('should store playerIds, acknowledgedBy: [], and status: pending in shared message metadata', async () => {
+      mockChannelDao.findDMBetweenUsers.mockResolvedValueOnce(null);
+      mockChannelDao.create.mockResolvedValueOnce({ id: 'dm-1', type: 'DM', members: [] });
+      mockMessageDao.create.mockResolvedValueOnce({ id: 'ack-1', createdAt: new Date() });
 
       await service.sendMatchAck('match-1', [10, 20], 'powerup', '2026-01-01T12:05:00Z');
 
-      // First call: player 10, opponent 20
-      const firstMeta = JSON.parse(mockMessageDao.create.mock.calls[0][0].metadata);
-      expect(firstMeta.opponentId).toBe(20);
+      const meta = JSON.parse(mockMessageDao.create.mock.calls[0][0].metadata);
+      expect(meta.playerIds).toEqual([10, 20]);
+      expect(meta.acknowledgedBy).toEqual([]);
+      expect(meta.status).toBe('pending');
+      expect(meta.matchId).toBe('match-1');
+    });
 
-      // Second call: player 20, opponent 10
-      const secondMeta = JSON.parse(mockMessageDao.create.mock.calls[1][0].metadata);
-      expect(secondMeta.opponentId).toBe(10);
+    it('should throw 400 for duplicate or fewer than 2 unique player IDs', async () => {
+      await expect(service.sendMatchAck('match-1', [1, 1], 'classic', '2026-01-01T12:05:00Z'))
+        .rejects.toThrow(new ChatError(400, 'sendMatchAck requires exactly 2 unique player IDs'));
     });
   });
 
@@ -481,93 +484,106 @@ describe('ChatService', () => {
   describe('respondToMatchAck', () => {
     const futureDate = new Date(Date.now() + 300_000).toISOString();
 
-    it('should acknowledge match and notify opponent', async () => {
+    const pendingMeta = (overrides: object = {}) => JSON.stringify({
+      matchId: 'match-1',
+      gameMode: 'classic',
+      playerIds: [1, 2],
+      acknowledgedBy: [],
+      expiresAt: futureDate,
+      status: 'pending',
+      ...overrides,
+    });
+
+    it('should add player to acknowledgedBy and emit bothAcked: false when first player acks', async () => {
       mockMessageDao.findById.mockResolvedValueOnce({
-        id: 'ack-1',
-        channelId: 'gs-1',
-        senderId: 0,
-        type: 'SYSTEM',
-        metadata: JSON.stringify({
-          matchId: 'match-1',
-          gameMode: 'classic',
-          opponentId: 2,
-          expiresAt: futureDate,
-          status: 'pending',
-        }),
+        id: 'ack-1', channelId: 'dm-1', metadata: pendingMeta(),
       });
-      mockChannelDao.isMember.mockResolvedValueOnce(true);
 
       const result = await service.respondToMatchAck('ack-1', 1, true);
 
-      expect(mockMessageDao.updateMetadata).toBeCalledWith(
-        'ack-1',
-        expect.stringContaining('"status":"acknowledged"')
-      );
-      expect(mockNotificationService.notifyUsers).toBeCalledWith([2], expect.objectContaining({
+      const saved = JSON.parse(mockMessageDao.updateMetadata.mock.calls[0][1]);
+      expect(saved.acknowledgedBy).toEqual([1]);
+      expect(saved.status).toBe('pending');
+      expect(mockNotificationService.notifyUsers).toBeCalledWith([1, 2], expect.objectContaining({
         type: 'chat:match_ack_response',
-        matchId: 'match-1',
         acknowledged: true,
+        bothAcked: false,
       }));
-      expect(result).toEqual({ acknowledged: true, matchId: 'match-1', gameMode: 'classic' });
+      expect(result).toEqual({ acknowledged: true, matchId: 'match-1', gameMode: 'classic', bothAcked: false });
     });
 
-    it('should decline match and set status to expired', async () => {
+    it('should set status to acknowledged and bothAcked: true when second player acks', async () => {
       mockMessageDao.findById.mockResolvedValueOnce({
-        id: 'ack-1',
-        channelId: 'gs-1',
-        metadata: JSON.stringify({
-          matchId: 'match-1',
-          gameMode: 'classic',
-          opponentId: 2,
-          expiresAt: futureDate,
-          status: 'pending',
-        }),
+        id: 'ack-1', channelId: 'dm-1', metadata: pendingMeta({ acknowledgedBy: [1] }),
       });
-      mockChannelDao.isMember.mockResolvedValueOnce(true);
+
+      const result = await service.respondToMatchAck('ack-1', 2, true);
+
+      const saved = JSON.parse(mockMessageDao.updateMetadata.mock.calls[0][1]);
+      expect(saved.acknowledgedBy).toEqual([1, 2]);
+      expect(saved.status).toBe('acknowledged');
+      expect(result.bothAcked).toBe(true);
+    });
+
+    it('should set status to declined and notify both players when a player cancels', async () => {
+      mockMessageDao.findById.mockResolvedValueOnce({
+        id: 'ack-1', channelId: 'dm-1', metadata: pendingMeta(),
+      });
 
       const result = await service.respondToMatchAck('ack-1', 1, false);
 
       expect(mockMessageDao.updateMetadata).toBeCalledWith(
         'ack-1',
-        expect.stringContaining('"status":"expired"')
+        expect.stringContaining('"status":"declined"')
       );
-      expect(result.acknowledged).toBe(false);
+      expect(mockNotificationService.notifyUsers).toBeCalledWith([1, 2], expect.objectContaining({
+        acknowledged: false,
+      }));
+      expect(result).toEqual({ acknowledged: false, matchId: 'match-1', gameMode: 'classic' });
     });
 
-    it('should throw 403 if caller is the opponent (not the intended recipient)', async () => {
+    it('should throw 403 if caller is not one of the matched players', async () => {
       mockMessageDao.findById.mockResolvedValueOnce({
-        id: 'ack-1',
-        channelId: 'gs-1',
-        metadata: JSON.stringify({
-          matchId: 'match-1',
-          gameMode: 'classic',
-          opponentId: 1,
-          expiresAt: futureDate,
-          status: 'pending',
-        }),
+        id: 'ack-1', channelId: 'dm-1', metadata: pendingMeta(),
+      });
+
+      await expect(service.respondToMatchAck('ack-1', 99, true)).rejects.toThrow(
+        new ChatError(403, 'You are not part of this match')
+      );
+    });
+
+    it('should throw 409 if player has already responded', async () => {
+      mockMessageDao.findById.mockResolvedValueOnce({
+        id: 'ack-1', channelId: 'dm-1', metadata: pendingMeta({ acknowledgedBy: [1] }),
       });
 
       await expect(service.respondToMatchAck('ack-1', 1, true)).rejects.toThrow(
-        new ChatError(403, 'This acknowledgement is not addressed to you')
+        new ChatError(409, 'You have already responded to this match')
       );
     });
 
-    it('should throw 403 if caller is not a member of the channel', async () => {
+    it('should throw 400 if match is already in a terminal state', async () => {
       mockMessageDao.findById.mockResolvedValueOnce({
-        id: 'ack-1',
-        channelId: 'gs-1',
-        metadata: JSON.stringify({
-          matchId: 'match-1',
-          gameMode: 'classic',
-          opponentId: 2,
-          expiresAt: futureDate,
-          status: 'pending',
-        }),
+        id: 'ack-1', channelId: 'dm-1', metadata: pendingMeta({ status: 'acknowledged' }),
       });
-      mockChannelDao.isMember.mockResolvedValueOnce(false);
 
-      await expect(service.respondToMatchAck('ack-1', 99, true)).rejects.toThrow(
-        new ChatError(403, 'Not a member of this channel')
+      await expect(service.respondToMatchAck('ack-1', 1, true)).rejects.toThrow(
+        new ChatError(400, 'Match already acknowledged')
+      );
+    });
+
+    it('should throw 410 and mark as expired if past deadline', async () => {
+      const pastDate = new Date(Date.now() - 60_000).toISOString();
+      mockMessageDao.findById.mockResolvedValueOnce({
+        id: 'ack-1', channelId: 'dm-1', metadata: pendingMeta({ expiresAt: pastDate }),
+      });
+
+      await expect(service.respondToMatchAck('ack-1', 1, true)).rejects.toThrow(
+        new ChatError(410, 'Match acknowledgement has expired')
+      );
+      expect(mockMessageDao.updateMetadata).toBeCalledWith(
+        'ack-1',
+        expect.stringContaining('"status":"expired"')
       );
     });
 
@@ -580,53 +596,10 @@ describe('ChatService', () => {
     });
 
     it('should throw 400 if message has no metadata', async () => {
-      mockMessageDao.findById.mockResolvedValueOnce({ id: 'msg-1', channelId: 'gs-1', metadata: null });
+      mockMessageDao.findById.mockResolvedValueOnce({ id: 'msg-1', channelId: 'dm-1', metadata: null });
 
       await expect(service.respondToMatchAck('msg-1', 1, true)).rejects.toThrow(
         new ChatError(400, 'Not a match acknowledgement message')
-      );
-    });
-
-    it('should throw 400 if already acknowledged', async () => {
-      mockMessageDao.findById.mockResolvedValueOnce({
-        id: 'ack-1',
-        channelId: 'gs-1',
-        metadata: JSON.stringify({
-          matchId: 'match-1',
-          gameMode: 'classic',
-          opponentId: 2,
-          expiresAt: futureDate,
-          status: 'acknowledged',
-        }),
-      });
-      mockChannelDao.isMember.mockResolvedValueOnce(true);
-
-      await expect(service.respondToMatchAck('ack-1', 1, true)).rejects.toThrow(
-        new ChatError(400, 'Acknowledgement already acknowledged')
-      );
-    });
-
-    it('should throw 410 and mark as expired if past deadline', async () => {
-      const pastDate = new Date(Date.now() - 60_000).toISOString();
-      mockMessageDao.findById.mockResolvedValueOnce({
-        id: 'ack-1',
-        channelId: 'gs-1',
-        metadata: JSON.stringify({
-          matchId: 'match-1',
-          gameMode: 'classic',
-          opponentId: 2,
-          expiresAt: pastDate,
-          status: 'pending',
-        }),
-      });
-      mockChannelDao.isMember.mockResolvedValueOnce(true);
-
-      await expect(service.respondToMatchAck('ack-1', 1, true)).rejects.toThrow(
-        new ChatError(410, 'Match acknowledgement has expired')
-      );
-      expect(mockMessageDao.updateMetadata).toBeCalledWith(
-        'ack-1',
-        expect.stringContaining('"status":"expired"')
       );
     });
   });


### PR DESCRIPTION
The flow to ack the game needed refactoring as it was introducing multiple fallacies and duplication that the new approach avoids.

- the channels are now multipurpose. if there is an active DM between two players who both joined the pool, the ack message will be sent in the chat prompting them to ack or cancel
- in case no DM channel is made it will be created, and message to ack will appear there
- no separate game session or system notifications chat

The bothAcked: true flag on the chat:match_ack_response WebSocket event is what the matchmaking/game service should listen for to trigger the actual game start. That handoff is unchanged from the existing pattern.  