### PR TITLE
Ack flow through chat

### DIFF
--- a/src/chat/src/index.ts
+++ b/src/chat/src/index.ts
@@ -6,6 +6,7 @@ import { ChannelDao } from './dao/channel.dao.js';
 import { MessageDao } from './dao/message.dao.js';
 import { NotificationService } from './services/notification.js';
 import { BlockService } from './services/block.js';
+import { MatchmakingClient } from './services/matchmaking-client.js';
 import { ChatService } from './services/chat.js';
 import { registerChannelRoutes } from './routes/channels.js';
 import { registerMessageRoutes } from './routes/messages.js';
@@ -40,7 +41,10 @@ const channelDao = new ChannelDao(prisma);
 const messageDao = new MessageDao(prisma);
 const notificationService = new NotificationService(channelDao, server.log);
 const blockService = new BlockService(server.log);
-const chatService = new ChatService(channelDao, messageDao, notificationService, blockService, server.log);
+const matchmakingClient = new MatchmakingClient(
+  process.env.MATCHMAKING_URL || 'http://localhost:3005'
+);
+const chatService = new ChatService(channelDao, messageDao, notificationService, blockService, server.log, matchmakingClient);
 
 // Health checks
 server.get('/health', async () => ({

--- a/src/chat/src/services/chat.ts
+++ b/src/chat/src/services/chat.ts
@@ -2,6 +2,7 @@ import { ChannelDao } from '../dao/channel.dao.js';
 import { MessageDao } from '../dao/message.dao.js';
 import { NotificationService } from './notification.js';
 import { BlockService } from './block.js';
+import { MatchmakingClient } from './matchmaking-client.js';
 import type { MatchAckMetadata } from '../types/chat.js';
 
 export class ChatService {
@@ -10,7 +11,8 @@ export class ChatService {
     private readonly messageDao: MessageDao,
     private readonly notificationService: NotificationService,
     private readonly blockService: BlockService,
-    private readonly logger?: { info: Function; error: Function; warn: Function }
+    private readonly logger?: { info: Function; error: Function; warn: Function },
+    private readonly matchmakingClient?: MatchmakingClient
   ) {}
 
   // ── Channels ──────────────────────────────────────────────
@@ -265,6 +267,16 @@ export class ChatService {
     if (!acknowledge) {
       metadata.status = 'declined';
       await this.messageDao.updateMetadata(messageId, JSON.stringify(metadata));
+
+      // Forward decline to matchmaking (cancels the match)
+      if (this.matchmakingClient) {
+        try {
+          await this.matchmakingClient.decline(metadata.matchId, playerId);
+        } catch (err) {
+          this.logger?.error({ err, matchId: metadata.matchId, playerId }, 'Failed to forward decline to matchmaking');
+        }
+      }
+
       await this.notificationService.notifyUsers(metadata.playerIds, {
         type: 'chat:match_ack_response',
         matchId: metadata.matchId,
@@ -279,6 +291,15 @@ export class ChatService {
     if (bothAcked) metadata.status = 'acknowledged';
 
     await this.messageDao.updateMetadata(messageId, JSON.stringify(metadata));
+
+    // Forward acknowledgement to matchmaking (triggers room creation when both acked)
+    if (this.matchmakingClient) {
+      try {
+        await this.matchmakingClient.acknowledge(metadata.matchId, playerId);
+      } catch (err) {
+        this.logger?.error({ err, matchId: metadata.matchId, playerId }, 'Failed to forward ack to matchmaking');
+      }
+    }
 
     await this.notificationService.notifyUsers(metadata.playerIds, {
       type: 'chat:match_ack_response',

--- a/src/chat/src/services/matchmaking-client.ts
+++ b/src/chat/src/services/matchmaking-client.ts
@@ -1,0 +1,47 @@
+/**
+ * MatchmakingClient
+ *
+ * Forwards match acknowledgement/decline decisions from the chat service
+ * to the matchmaking service so it can create game rooms or cancel matches.
+ */
+export class MatchmakingClient {
+  constructor(private readonly matchmakingUrl: string) {}
+
+  /**
+   * Forward a player's acknowledgement to the matchmaking service.
+   * Returns the matchmaking response (includes bothReady and roomId when both acked).
+   */
+  async acknowledge(matchId: string, playerId: number): Promise<{ bothReady: boolean; roomId: string | null }> {
+    const response = await fetch(`${this.matchmakingUrl}/match/${matchId}/acknowledge`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-user-id': String(playerId)
+      }
+    });
+
+    if (!response.ok) {
+      throw new Error(`Matchmaking returned ${response.status} when acknowledging match ${matchId}`);
+    }
+
+    return await response.json() as { bothReady: boolean; roomId: string | null };
+  }
+
+  /**
+   * Forward a player's decline to the matchmaking service.
+   * The match will be cancelled.
+   */
+  async decline(matchId: string, playerId: number): Promise<void> {
+    const response = await fetch(`${this.matchmakingUrl}/match/${matchId}/decline`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-user-id': String(playerId)
+      }
+    });
+
+    if (!response.ok) {
+      throw new Error(`Matchmaking returned ${response.status} when declining match ${matchId}`);
+    }
+  }
+}

--- a/src/matchmaking/prisma/schema.prisma
+++ b/src/matchmaking/prisma/schema.prisma
@@ -28,6 +28,7 @@ enum MatchStatus {
   COMPLETED                // Result recorded
   FORFEITED                // Player left or failed to acknowledge
   TIMEOUT                  // Deadline passed without starting
+  CANCELLED                // Player declined the match
 }
 
 // NOTE: PlayerPool is kept in-memory only (no database persistence)

--- a/src/matchmaking/src/dao/match.ts
+++ b/src/matchmaking/src/dao/match.ts
@@ -119,7 +119,7 @@ export class MatchDao {
 
     if (status === 'IN_PROGRESS') {
       updateData.startedAt = new Date();
-    } else if (status === 'COMPLETED' || status === 'FORFEITED' || status === 'TIMEOUT') {
+    } else if (status === 'COMPLETED' || status === 'FORFEITED' || status === 'TIMEOUT' || status === 'CANCELLED') {
       updateData.completedAt = new Date();
     }
 
@@ -297,6 +297,34 @@ export class MatchDao {
           { player2Id: { in: playerIds } }
         ],
         status: 'COMPLETED'
+      }
+    });
+  }
+
+  /**
+   * Decline/cancel a match. Sets status to CANCELLED with no scores.
+   * Only allowed while the match is still PENDING_ACKNOWLEDGEMENT.
+   */
+  async declineMatch(matchId: string, decliningPlayerId: number): Promise<Match> {
+    const match = await this.findById(matchId);
+    if (!match) {
+      throw new Error(`Match ${matchId} not found`);
+    }
+
+    if (match.status !== 'PENDING_ACKNOWLEDGEMENT') {
+      throw new Error(`Match ${matchId} is ${match.status}, cannot decline`);
+    }
+
+    if (match.player1Id !== decliningPlayerId && match.player2Id !== decliningPlayerId) {
+      throw new Error(`Player ${decliningPlayerId} is not part of match ${matchId}`);
+    }
+
+    return await this.prisma.match.update({
+      where: { id: matchId },
+      data: {
+        status: 'CANCELLED',
+        resultSource: `declined:${decliningPlayerId}`,
+        completedAt: new Date()
       }
     });
   }

--- a/src/matchmaking/src/routes/match.ts
+++ b/src/matchmaking/src/routes/match.ts
@@ -104,6 +104,41 @@ export async function registerMatchRoutes(
   });
 
   /**
+   * POST /match/:matchId/decline
+   * Player declines the match. Match is cancelled (no scores, no winner).
+   */
+  server.post('/match/:matchId/decline', async (request: FastifyRequest, reply: FastifyReply) => {
+    const { matchId } = request.params as { matchId: string };
+    const userId = getUserIdFromHeader(request);
+
+    if (userId === null) {
+      return reply.status(401).send({
+        error: 'Unauthorized',
+        message: 'Missing x-user-id header'
+      });
+    }
+
+    try {
+      const updatedMatch = await matchDao.declineMatch(matchId, userId);
+      request.log.info({ matchId, userId }, 'Match declined');
+
+      return reply.status(200).send({
+        success: true,
+        matchId: updatedMatch.id,
+        status: updatedMatch.status
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to decline match';
+      const isValidation = message.includes('not found') || message.includes('cannot decline') || message.includes('not part of');
+      request.log.error({ error, matchId, userId }, 'Error declining match');
+      return reply.status(isValidation ? 400 : 500).send({
+        error: isValidation ? 'Bad Request' : 'Internal Server Error',
+        message
+      });
+    }
+  });
+
+  /**
    * GET /match/:matchId
    * Get match details
    */


### PR DESCRIPTION
Fix ack flow through chat endpoint. payload should have boolean acknowledge: true/false.

Example request:
POST http://localhost:3000/api/chat/match-ack/:messageId/respond \
  -d '{"acknowledge": true}'

