### PR TITLE
TRAN-277 Use unified event for tournament updates

### DIFF
--- a/src/matchmaking/src/routes/tournament.ts
+++ b/src/matchmaking/src/routes/tournament.ts
@@ -110,8 +110,8 @@ export async function registerTournamentRoutes(
 
       // Broadcast to all connected users so they can update the tournament list
       gatewayNotificationClient.broadcastEvent({
-        type: 'TOURNAMENT_CREATED',
-        tournament
+        type: 'TOURNAMENT_UPDATE',
+        tournamentId: tournament.id
       });
 
       return reply.status(201).send({
@@ -245,6 +245,11 @@ export async function registerTournamentRoutes(
 
       request.log.info({ tournamentId, userId }, 'Tournament cancelled');
 
+      gatewayNotificationClient.broadcastEvent({
+        type: 'TOURNAMENT_UPDATE',
+        tournamentId
+      });
+
       return reply.status(200).send({
         success: true,
         tournament
@@ -310,6 +315,11 @@ export async function registerTournamentRoutes(
 
       request.log.info({ tournamentId, userId, full }, 'User registered for tournament');
 
+      gatewayNotificationClient.broadcastEvent({
+        type: 'TOURNAMENT_UPDATE',
+        tournamentId
+      });
+
       // If tournament is now full, trigger early registration close
       if (full) {
         lifecycleManager?.onRegistrationFull(tournamentId).catch(err => {
@@ -366,6 +376,11 @@ export async function registerTournamentRoutes(
       await tournamentService.unregister(tournamentId, userId);
 
       request.log.info({ tournamentId, userId }, 'User unregistered from tournament');
+
+      gatewayNotificationClient.broadcastEvent({
+        type: 'TOURNAMENT_UPDATE',
+        tournamentId
+      });
 
       return reply.status(200).send({
         success: true,

--- a/src/matchmaking/src/services/tournament-lifecycle.ts
+++ b/src/matchmaking/src/services/tournament-lifecycle.ts
@@ -284,8 +284,17 @@ export class TournamentLifecycleManager {
 
       if (tournament.status === 'CANCELLED') {
         this.log('info', `Tournament ${tournamentId} cancelled due to insufficient players`);
+        this.gatewayNotificationClient.broadcastEvent({
+          type: 'TOURNAMENT_UPDATE',
+          tournamentId
+        });
         return;
       }
+
+      this.gatewayNotificationClient.broadcastEvent({
+        type: 'TOURNAMENT_UPDATE',
+        tournamentId
+      });
 
       // If no startTime, start immediately
       if (!tournament.startTime) {

--- a/src/matchmaking/src/services/tournament.ts
+++ b/src/matchmaking/src/services/tournament.ts
@@ -158,6 +158,13 @@ export class TournamentService {
       );
     }
 
+    if (tournament.createdBy === userId) {
+      throw new TournamentError(
+        'Tournament creator cannot unregister. Cancel the tournament instead.',
+        'CREATOR_CANNOT_LEAVE'
+      );
+    }
+
     const isRegistered = await this.participantDao.isRegistered(tournamentId, userId);
     if (!isRegistered) {
       throw new TournamentError('Not registered for this tournament', 'NOT_REGISTERED');

--- a/src/matchmaking/test/services/tournament-lifecycle.test.ts
+++ b/src/matchmaking/test/services/tournament-lifecycle.test.ts
@@ -102,6 +102,7 @@ describe('TournamentLifecycleManager', () => {
 
     mockGatewayNotificationClient = {
       notifyUsers: vi.fn(),
+      broadcastEvent: vi.fn(),
     } as unknown as GatewayNotificationClient;
 
     manager = new TournamentLifecycleManager(


### PR DESCRIPTION
This diff builds on the mechanism to broadcast the notifications to all open connections that was introduced to inform frontend about tournamnet creation, and makes it a unified event that will be emitted also on new user joining/leaving the tournament, cancelling the tournament, registrations ending.

Also added a defensive check not allowing the creator to leave tournament that they created, they can only cancel.