### PR TITLE
TRAN-344 added network name to docker-compose-dev

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -270,4 +270,5 @@ volumes:
 
 networks:
   app-net:
+    name: transcendence-app
     driver: bridge


### PR DESCRIPTION
In order to run docker-compose-dev with observability the network name needs to match. This PR fixes that