### PR TITLE
TRAN-346 fix database permissions in dev env

### DIFF
--- a/src/chat/entrypoint-dev.sh
+++ b/src/chat/entrypoint-dev.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 
+# INFO:create database before giving app user permission
+npm run db:push
+
 # INFO:give dev user access to data volume
 chown -R app:appgroup /data
 
-npm run db:push
 npx prisma studio --browser none --port 51215 &
 
 # INFO:run program from script argument as dev user

--- a/src/matchmaking/entrypoint-dev.sh
+++ b/src/matchmaking/entrypoint-dev.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 
+# INFO:create database before giving app user permission
+npm run db:push
+
 # INFO:give dev user access to data volume
 chown -R app:appgroup /data
 
-npm run db:push
 npx prisma studio --browser none --port 51214 &
 
 # INFO:run program from script argument as dev user


### PR DESCRIPTION
Fixes the permission right of dev user in docker containers to write to database. dev user never had write permission for database files so the database file was readonly. Now database is created before permission change to dev user. 