### PR TITLE
Add remote play setup with Nginx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,19 @@
 NAME	:= .docker_compose_started
 
 COMPOSE_APP  = docker compose -f docker-compose.yml
-COMPOSE_DEV = docker compose -f docker-compose-dev.yml -f docker-compose.observability.yml
+COMPOSE_DEV  = docker compose -f docker-compose-dev.yml -f docker-compose.observability.yml
 COMPOSE_PROD = docker compose -f docker-compose.yml -f docker-compose.observability.yml
+COMPOSE_OBS  = docker compose -f docker-compose.observability.yml
+
+# Detect the machine's primary LAN IP automatically.
+# Override at the command line: make remote HOST_IP=10.x.x.x
+HOST_IP ?= $(shell ip route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($$i=="src") print $$(i+1)}' | head -1)
+ifeq ($(HOST_IP),)
+HOST_IP := $(shell ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1 2>/dev/null || echo localhost)
+endif
+
+# Vite build args passed to Docker so the frontend bundle points at this machine
+VITE_ARGS = VITE_API_URL=https://$(HOST_IP) VITE_GAME_URL=https://$(HOST_IP)/colyseus
 
 all: $(NAME)
 
@@ -18,6 +29,12 @@ fclean: clean
 
 re: fclean all
 
+# ── TLS certificate ───────────────────────────────────────────────────────────
+
+cert:
+	@echo "Generating TLS certificate for IP: $(HOST_IP)"
+	@bash scripts/gen-cert.sh $(HOST_IP)
+
 # ── Dev (app services only, pino-pretty logs) ────────────────────────────────
 
 dev:
@@ -30,16 +47,46 @@ dev-build:
 dev-down:
 	$(COMPOSE_DEV) down
 
+# ── Remote play / evaluation (LAN, two separate machines) ────────────────────
+# Generates a cert for this machine's IP, builds the frontend with the correct
+# URLs baked in, then starts the full stack.
+#
+# Usage:
+#   make remote              # auto-detects LAN IP
+#   make remote HOST_IP=10.x.x.x   # or pass it explicitly
+#
+# Both players open https://$(HOST_IP) in their browser.
+# Accept the self-signed certificate warning to proceed.
+
+remote: cert
+	$(VITE_ARGS) $(COMPOSE_APP) up -d --build
+	touch $(NAME)
+
+remote-down:
+	$(COMPOSE_APP) down
+	rm -rf $(NAME)
+
 # ── Prod (app + observability stack) ─────────────────────────────────────────
 
 prod:
 	$(COMPOSE_PROD) up -d
 
 prod-build:
-	$(COMPOSE_PROD) up -d --build
+	$(VITE_ARGS) $(COMPOSE_PROD) up -d --build
 
 prod-down:
 	$(COMPOSE_PROD) down
+
+# ── Observability stack only (ELK + Prometheus + Grafana) ────────────────────
+
+obs:
+	$(COMPOSE_OBS) up -d
+
+obs-build:
+	$(COMPOSE_OBS) up -d --build
+
+obs-down:
+	$(COMPOSE_OBS) down
 
 # ── Utilities ─────────────────────────────────────────────────────────────────
 
@@ -53,4 +100,4 @@ $(NAME):
 	$(COMPOSE_APP) up --build
 	touch $(NAME)
 
-.PHONY: all clean fclean re dev dev-build dev-down prod prod-build prod-down logs ps
+.PHONY: all clean fclean re cert dev dev-build dev-down remote remote-down prod prod-build prod-down obs obs-build obs-down logs ps

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -1,0 +1,110 @@
+# Transcendence — Project Overview
+
+## Running the project
+
+### Local development (single machine)
+
+```sh
+make dev-build
+```
+
+Open `http://localhost:5173` in your browser.
+
+---
+
+### Remote play / evaluation (two separate machines on the same LAN)
+
+The frontend URLs are baked into the bundle at Docker build time via Vite's `VITE_*` env vars.
+For two players on separate machines you need to build the frontend pointing at the host machine's
+LAN IP, and serve everything over HTTPS.
+
+`make remote` handles all of this in one step:
+
+```sh
+make remote
+# or, if auto-detection fails:
+make remote HOST_IP=10.x.x.x
+```
+
+What it does:
+1. Detects (or uses the provided) LAN IP.
+2. Runs `scripts/gen-cert.sh` to generate a self-signed TLS certificate with that IP as a Subject Alternative Name, stored in `certs/`.
+3. Builds the frontend Docker image with `VITE_API_URL=https://<ip>` and `VITE_GAME_URL=https://<ip>/colyseus` baked in.
+4. Starts the full stack (nginx + all services).
+
+Both players open `https://<host-ip>` in their browsers.
+Browsers will show a security warning for the self-signed cert — click **Advanced → Proceed**
+(or type `thisisunsafe` in Chrome with the page focused).
+
+To stop:
+
+```sh
+make remote-down
+```
+
+#### How the URLs work
+
+| Env var | Default (local dev) | Remote play |
+|---------|---------------------|-------------|
+| `VITE_API_URL` | `http://localhost:3000` | `https://<host-ip>` |
+| `VITE_GAME_URL` | `http://localhost:2567` | `https://<host-ip>/colyseus` |
+
+`VITE_API_URL` drives all REST calls and the notification WebSocket (`wss://` is derived from it automatically).
+`VITE_GAME_URL` drives the Colyseus game-room connection.
+
+Both variables are declared in [`src/frontend/src/vite-env.d.ts`](src/frontend/src/vite-env.d.ts) and
+consumed in [`src/frontend/src/shared/config/AppConfig.ts`](src/frontend/src/shared/config/AppConfig.ts)
+and [`src/frontend/src/components/providers/Room.tsx`](src/frontend/src/components/providers/Room.tsx).
+
+#### TLS / nginx
+
+nginx terminates TLS on port 443 and proxies:
+- `/colyseus/*` → game-server:2567 (Colyseus WebSocket)
+- everything else → api-gateway:3000 (REST + notification WebSocket)
+
+Internal service-to-service traffic stays on plain HTTP inside the Docker bridge network.
+Only the nginx container needs the certificate.
+
+---
+
+### Production (app + full observability stack)
+
+```sh
+make prod-build HOST_IP=<ip>
+```
+
+Observability stack only (ELK + Prometheus + Grafana):
+
+```sh
+make obs
+```
+
+---
+
+## Makefile targets
+
+| Target | Description |
+|--------|-------------|
+| `make` / `make all` | Build and start the app stack |
+| `make cert` | Generate TLS cert for `HOST_IP` (auto-detected or explicit) |
+| `make remote` | Cert + build + start for LAN remote play |
+| `make remote-down` | Stop the remote stack |
+| `make dev` | Start dev stack with file watching |
+| `make dev-build` | Build and start dev stack |
+| `make prod-build` | Build and start app + observability |
+| `make obs` | Start observability stack only |
+| `make logs` | Tail all service logs |
+| `make ps` | Show running containers |
+| `make clean` | Stop and remove volumes |
+| `make fclean` | Full Docker purge |
+
+---
+
+## Further reading
+
+- [Docker setup and volumes](docs/DOCKER.md)
+- [API gateway routing](docs/API-GATEWAY.md)
+- [Matchmaking architecture](docs/MATCHMAKING_ARCHITECTURE.md)
+- [Observability guide](docs/OBSERVABILITY_GUIDE.md)
+- [Requirements audit](docs/REQUIREMENTS_AUDIT.md)
+- [Finalization plan](docs/FINALIZATION_PLAN.md)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,25 @@
 services:
 
+  # ─── Nginx (TLS termination + reverse proxy) ────────────────────────────────
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./certs:/etc/nginx/certs:ro
+    depends_on:
+      - api-gateway
+      - game-server
+    networks:
+      - app-net
+    deploy:
+      restart_policy:
+        condition: any
+        delay: 5s
+        window: 15s
+
   # ─── API Gateway ────────────────────────────────────────────────────────────
   api-gateway:
     build:
@@ -42,6 +62,11 @@ services:
     build:
       context: src/frontend
       dockerfile: Dockerfile
+      args:
+        # Vite bakes these into the bundle at build time.
+        # Pass HOST_IP when building for LAN play: HOST_IP=x.x.x.x docker compose up --build
+        - VITE_API_URL=${VITE_API_URL:-https://localhost}
+        - VITE_GAME_URL=${VITE_GAME_URL:-https://localhost/colyseus}
     ports:
       - "5173:5173"
     depends_on:

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -68,7 +68,6 @@ USER_MANAGEMENT_URL=http://user-management:3004
 CHAT_SERVICE_URL=http://chat:3006
 MATCHMAKING_URL=http://matchmaking:3005
 GAME_SERVER_URL=http://game-server:2567
-API_GATEWAY_URL=http://api-gateway:3000
 GATEWAY_URL=http://api-gateway:3000
 
 NODE_ENV=production

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,48 @@
+events {
+  worker_connections 1024;
+}
+
+http {
+  # ── Redirect HTTP → HTTPS ──────────────────────────────────────────────────
+  server {
+    listen 80;
+    return 301 https://$host$request_uri;
+  }
+
+  # ── HTTPS entry point ──────────────────────────────────────────────────────
+  server {
+    listen 443 ssl;
+
+    ssl_certificate     /etc/nginx/certs/server.crt;
+    ssl_certificate_key /etc/nginx/certs/server.key;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_ciphers         HIGH:!aNULL:!MD5;
+
+    # Raise limit for avatar uploads
+    client_max_body_size 10M;
+
+    # ── Colyseus game server (WebSocket) ─────────────────────────────────────
+    # Must be listed before the catch-all so the more specific prefix wins.
+    location /colyseus/ {
+      proxy_pass         http://game-server:2567/;
+      proxy_http_version 1.1;
+      proxy_set_header   Upgrade    $http_upgrade;
+      proxy_set_header   Connection "upgrade";
+      proxy_set_header   Host       $host;
+      proxy_read_timeout 3600s;
+      proxy_send_timeout 3600s;
+    }
+
+    # ── API gateway — REST + notification WebSocket ───────────────────────────
+    location / {
+      proxy_pass         http://api-gateway:3000;
+      proxy_http_version 1.1;
+      proxy_set_header   Upgrade    $http_upgrade;
+      proxy_set_header   Connection "upgrade";
+      proxy_set_header   Host       $host;
+      proxy_set_header   X-Real-IP  $remote_addr;
+      proxy_read_timeout 3600s;
+      proxy_send_timeout 3600s;
+    }
+  }
+}

--- a/scripts/gen-cert.sh
+++ b/scripts/gen-cert.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Generate a self-signed TLS certificate with Subject Alternative Names for
+# both localhost and the machine's LAN IP.
+#
+# Usage:
+#   bash scripts/gen-cert.sh [IP]
+#
+# If IP is omitted, the script detects the primary LAN IP automatically.
+# Output: certs/server.crt  certs/server.key
+
+set -euo pipefail
+
+CERT_DIR="$(cd "$(dirname "$0")/.." && pwd)/certs"
+mkdir -p "$CERT_DIR"
+
+# ── Resolve IP ────────────────────────────────────────────────────────────────
+if [ -n "${1:-}" ]; then
+  HOST_IP="$1"
+else
+  # Works on Linux (school iMacs) and macOS
+  if command -v ip &>/dev/null; then
+    HOST_IP=$(ip route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i=="src") print $(i+1)}' | head -1)
+  else
+    HOST_IP=$(ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1 2>/dev/null || echo "")
+  fi
+fi
+
+if [ -z "${HOST_IP:-}" ]; then
+  echo "ERROR: Could not detect LAN IP. Pass it explicitly: bash scripts/gen-cert.sh 10.x.x.x"
+  exit 1
+fi
+
+echo "Generating cert for IP: $HOST_IP  (+ localhost / 127.0.0.1)"
+
+# Source: https://stackoverflow.com/a/41366949 (vog, CC BY-SA 4.0)
+openssl req -x509 -newkey ed25519 -days 3650 \
+  -noenc \
+  -keyout "$CERT_DIR/server.key" \
+  -out    "$CERT_DIR/server.crt" \
+  -subj   "/CN=$HOST_IP" \
+  -addext "subjectAltName=DNS:localhost,IP:127.0.0.1,IP:$HOST_IP"
+
+echo "Done."
+echo "  $CERT_DIR/server.crt"
+echo "  $CERT_DIR/server.key"
+echo ""
+echo "Players will see a browser security warning — click Advanced → Proceed"
+echo "(or type 'thisisunsafe' in Chrome)."

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -4,6 +4,15 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY . .
+
+# Vite replaces import.meta.env.VITE_* at build time.
+# Pass HOST_IP when building for LAN/remote play:
+#   VITE_API_URL=https://10.x.x.x VITE_GAME_URL=https://10.x.x.x/colyseus docker compose up --build
+ARG VITE_API_URL=https://localhost
+ARG VITE_GAME_URL=https://localhost/colyseus
+ENV VITE_API_URL=$VITE_API_URL
+ENV VITE_GAME_URL=$VITE_GAME_URL
+
 RUN npm run build
 CMD npm run prod
  

--- a/src/frontend/src/components/providers/Room.tsx
+++ b/src/frontend/src/components/providers/Room.tsx
@@ -20,7 +20,7 @@ let room!: Room;
 // Workaround for React.StrictMode, to avoid multiple join requests
 //
 let hasActiveJoinRequest: boolean = false;
-const client = new Client("http://localhost:2567");
+const client = new Client(import.meta.env.VITE_GAME_URL ?? 'http://localhost:2567');
 
 export function RoomProvider({ children }: { children: ReactNode }) {
     const [joinError, setJoinError] = useState<boolean>(false);

--- a/src/frontend/src/features/matchmaking/CurrentGames.tsx
+++ b/src/frontend/src/features/matchmaking/CurrentGames.tsx
@@ -2,7 +2,7 @@ import { useLobbyRoom } from "@colyseus/react";
 import { Client } from "@colyseus/sdk";
 import { JSX } from "react";
 
-const client = new Client("ws://localhost:2567");
+const client = new Client(import.meta.env.VITE_GAME_URL ?? 'ws://localhost:2567');
 
 export function CurrentGames(): JSX.Element {
     const { rooms, error, isConnecting } = useLobbyRoom(

--- a/src/frontend/src/shared/config/AppConfig.ts
+++ b/src/frontend/src/shared/config/AppConfig.ts
@@ -74,7 +74,7 @@ export const CONFIG = {
   CANCEL_JOIN_BUTTON: 'cancel',
 
   // NOTE: AXIOS
-  REQUEST_BASE_URL: 'http://localhost:3000/api/',
+  REQUEST_BASE_URL: `${import.meta.env.VITE_API_URL ?? 'http://localhost:3000'}/api/`,
   REQUEST_REGISTER: 'auth/register',
   REQUEST_REGISTER_METHOD: 'POST',
   REQUEST_REGISTER_HEADERS: {
@@ -179,5 +179,6 @@ export const CONFIG = {
   MATCHMAKING_CONTAINER_ID: 'MatchmakingContainer',
 
   // NOTE: NOTIFICATIONS
-  NOTIFICATION_URI: 'ws://localhost:3000/ws'
+  // Derives wss:// from the VITE_API_URL (https → wss, http → ws).
+  NOTIFICATION_URI: `${(import.meta.env.VITE_API_URL ?? 'http://localhost:3000').replace(/^http/, 'ws')}/ws`
 };

--- a/src/frontend/src/vite-env.d.ts
+++ b/src/frontend/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_URL?: string
+  readonly VITE_GAME_URL?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -3,6 +3,14 @@ import react from '@vitejs/plugin-react-swc';
 import tailwindcss from '@tailwindcss/vite';
 
 // https://vite.dev/config/
+//
+// Build-time environment variables (injected via Docker build args, see PROJECT.md):
+//   VITE_API_URL  — base URL for the API gateway  (default: http://localhost:3000)
+//   VITE_GAME_URL — base URL for the Colyseus game server (default: http://localhost:2567)
+//
+// These are baked into the bundle at build time by Vite (import.meta.env.VITE_*).
+// To build for remote play: VITE_API_URL=https://<ip> VITE_GAME_URL=https://<ip>/colyseus docker compose up --build
+// Or simply: make remote   (auto-detects LAN IP and handles cert + build)
 export default defineConfig({
   plugins: [
     tailwindcss() as UserConfig['plugins'],

--- a/src/user-management/src/config/set-up-controllers.ts
+++ b/src/user-management/src/config/set-up-controllers.ts
@@ -26,7 +26,7 @@ export function composeDependencies() {
   const prisma = getPrismaClient();
 
   const authClient = new AuthClient(env.AUTH_SERVICE_URL, 1000);
-  const apiGatewayClient = new ApiGatewayClient(env.API_GATEWAY_URL, 1000);
+  const apiGatewayClient = new ApiGatewayClient(env.GATEWAY_URL, 1000);
   const userRepository = new UserRepository(prisma);
   const profRepository = new ProfileRepository(prisma);
   const friendRepository = new FriendshipRepository(prisma);

--- a/src/user-management/src/schemas/env.ts
+++ b/src/user-management/src/schemas/env.ts
@@ -34,9 +34,9 @@ export const  EnvSchema = z.object({
     .url('AUTH_SERVICE_URL must be a valid URL')
     .startsWith('http', 'AUTH_SERVICE_URL must start with http:// or https://'),
 
-  API_GATEWAY_URL: z.string()
-    .url('API_GATEWAY_URL must be a valid URL')
-    .startsWith('http', 'API_GATEWAY_URL must start with http:// or https://'),
+  GATEWAY_URL: z.string()
+    .url('GATEWAY_URL must be a valid URL')
+    .startsWith('http', 'GATEWAY_URL must start with http:// or https://'),
 
   UPLOAD_DIR: z.string().default('uploads'),
   PREFIX: z.string().default('/uploads/'),


### PR DESCRIPTION
In order to allow remote play from separate devices we need to introduce Nginx proxy that will allow players making call to host machine when machines are on the same network. 