### PR TITLE
Fix several user management/auth related bugs

### DIFF
--- a/src/auth/src/dao/2fa.dao.ts
+++ b/src/auth/src/dao/2fa.dao.ts
@@ -65,7 +65,7 @@ export class TwoFactorAuthDao implements ITwoFactorAuthDao {
 
 
   async delete(user_id: number): Promise<void> {
-    await this.prismaClient.twoFactorAuth.delete({
+    await this.prismaClient.twoFactorAuth.deleteMany({
       where: { user_id: user_id }
     });
   }

--- a/src/auth/src/services/auth.ts
+++ b/src/auth/src/services/auth.ts
@@ -274,7 +274,7 @@ export class AuthService {
       await this.twoFactorAuthDao.create(user_id, secret);
       
       const uri = generateURI({
-        issuer: 'Auth service',
+        issuer: 'Transcendence',
         label: user.email,
         secret
       });

--- a/src/chat/src/services/chat.ts
+++ b/src/chat/src/services/chat.ts
@@ -318,12 +318,22 @@ export class ChatService {
       ...(tournamentName != null && { tournamentName })
     };
 
+    const minutesToConfirm = Math.round((new Date(expiresAt).getTime() - Date.now()) / 60_000);
+    const timeToConfirm = `Time to confirm: ${minutesToConfirm} min.`;
+
+    let content: string;
+    if (tournamentName) {
+      content = `Upcoming game in ${tournamentName}. Both players must acknowledge to start. ${timeToConfirm}`;
+    } else if (challengerUsername) {
+      content = `Friendly challenge from ${challengerUsername}! Game mode: ${gameMode}. Both players must acknowledge to start. ${timeToConfirm}`;
+    } else {
+      content = `Match found! Game mode: ${gameMode}. Both players must acknowledge to start. ${timeToConfirm}`;
+    }
+
     const message = await this.messageDao.create({
       channelId: channel.id,
       senderId: 0,
-      content: challengerUsername
-        ? `Friendly challenge from ${challengerUsername}! Game mode: ${gameMode}. Both players must acknowledge to start.`
-        : `Match found! Game mode: ${gameMode}. Both players must acknowledge to start.`,
+      content,
       type: 'SYSTEM',
       metadata: JSON.stringify(metadata)
     });

--- a/src/frontend/src/components/hooks/Notifications.tsx
+++ b/src/frontend/src/components/hooks/Notifications.tsx
@@ -30,6 +30,9 @@ export function useNotifications() {
                     if (msg.type === 'MATCH_JOINED_POOL' || msg.type === 'MATCH_LEAVED_POOL') {
                         setMatchUpdate(event.timeStamp)
                     }
+                    if (msg.type === 'chat:channel_created') {
+                        setChatUpdate(event.timeStamp);
+                    }
                     if (msg.type === 'chat:match_ack_required') {
                         setMatchUpdate(event.timeStamp)
                         setChatUpdate(event.timeStamp);

--- a/src/frontend/src/components/providers/Auth.tsx
+++ b/src/frontend/src/components/providers/Auth.tsx
@@ -3,6 +3,7 @@ import {
     useContext,
     useLayoutEffect,
     useState,
+    useRef,
     ReactNode,
     JSX,
     useEffect
@@ -30,7 +31,7 @@ export function useAuth() {
 
 export function AuthProvider({ children }: { children: ReactNode }): JSX.Element {
     const [token, setToken] = useState<string>('');
-    const [retry, setRetry] = useState<boolean>(false);
+    const isRefreshing = useRef<boolean>(false);
     const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null);
     const [isLoading, setIsLoading] = useState<boolean>(true);
     const { userId, setUserId, removeUserId } = useUserId();
@@ -157,19 +158,24 @@ export function AuthProvider({ children }: { children: ReactNode }): JSX.Element
             return config;
         }, async (error) => {
             if (error.response?.status === 401) {
-                if (retry) {
-                    setRetry(false);
+                if (isRefreshing.current) {
                     return Promise.reject(error);
                 }
-                setRetry(true);
-                refresh();
-                return api(error.config);
+                isRefreshing.current = true;
+                try {
+                    await refresh();
+                    return api(error.config);
+                } catch (e) {
+                    return Promise.reject(e);
+                } finally {
+                    isRefreshing.current = false;
+                }
             }
             return Promise.reject(error);
         });
 
         return function cleanup() {
-            api.interceptors.request.eject(refreshIntercept);
+            api.interceptors.response.eject(refreshIntercept);
         };
     }, [token]);
 

--- a/src/frontend/src/features/live-chat/LiveChatUsers.tsx
+++ b/src/frontend/src/features/live-chat/LiveChatUsers.tsx
@@ -62,13 +62,13 @@ export function UserSearchBar({ setProfile }: { setProfile: Dispatch<SetStateAct
             <div className="min-h-full flex">
                 <form className="min-h-full min-w-full flex" onSubmit={submit}>
                     <div className="min-w-4/5 min-h-full">
-                        <textarea
+                        <input
+                            type="text"
                             id="user-search-input-element"
                             name="user-search-input"
                             className="border w-full min-h-full"
                             value={content}
                             onChange={e => setContent(e.target.value)}
-                            rows={0}
                         />
                     </div>
                     <div id="user-search-send-button" className="min-w-1/5 min-h-full">

--- a/src/frontend/src/features/live-chat/MessageForm.tsx
+++ b/src/frontend/src/features/live-chat/MessageForm.tsx
@@ -24,7 +24,8 @@ export function MessageForm({ channelId, onMessageAdded }: { channelId: string, 
             <div className="min-h-full flex">
                 <form className="min-h-full min-w-full flex" onSubmit={submit}>
                     <div className="min-w-4/5 min-h-full">
-                        <textarea
+                        <input
+                            type="text"
                             id="message-input-element"
                             name="message-input"
                             className="border w-full min-h-full"

--- a/src/frontend/src/features/live-chat/RenderMessage.tsx
+++ b/src/frontend/src/features/live-chat/RenderMessage.tsx
@@ -14,14 +14,11 @@ export function RenderAckMessage({ item }: { item: IChatMessage }) {
         }
     }
     return (
-        <li key={item.id}>
-            <br />
-            <div className="border border-white flex justify-between">
-                <div></div>
+        <RenderMessageContainer id={item.id}>
+            <RenderMessageDate item={item} />
+            <RenderMessageContentContainer id={item.id}>
                 <div className="flex flex-col">
-                    <div>
-                        {item.content}
-                    </div>
+                    <div>{item.content}</div>
                     <br />
                     <div className="flex justify-between">
                         <div></div>
@@ -30,14 +27,12 @@ export function RenderAckMessage({ item }: { item: IChatMessage }) {
                             <div />
                             <button onClick={() => sendAck(item.id, false)} className="bg-red-500">Cancel</button>
                         </div>
-
                         <div></div>
                     </div>
                     <br />
                 </div>
-                <div></div>
-            </div>
-        </li>
+            </RenderMessageContentContainer>
+        </RenderMessageContainer>
     )
 }
 

--- a/src/frontend/src/features/profile/DeleteUser.tsx
+++ b/src/frontend/src/features/profile/DeleteUser.tsx
@@ -1,11 +1,10 @@
 import { useState } from "react";
 import { SubmitPropertyChangeYesNo } from "./Submit";
 import { useUserService } from "../../components/providers/User";
-import { useNavigate } from "react-router-dom";
-import { HOME_NAVIGATION } from "../../shared/constants/navigation";
+import { useAuth } from "../../components/providers/Auth";
 
 export function DeleteUser() {
-    const navigate = useNavigate();
+    const auth = useAuth();
     const userService = useUserService();
     const [showDropdown, setShowDropDown] = useState<boolean>(false);
 
@@ -18,7 +17,7 @@ export function DeleteUser() {
             await userService.deleteUser();
             handleDropDown();
             alert("Deleted account!");
-            navigate(HOME_NAVIGATION)
+            try { await auth.refresh(); } catch { }
         } catch (error) {
             console.error("Error deleting Account:", error);
             alert("Deleting account failed");

--- a/src/frontend/src/features/profile/Email.tsx
+++ b/src/frontend/src/features/profile/Email.tsx
@@ -4,7 +4,7 @@ import { SubmitPropertyChange } from "./Submit";
 import { IUser } from "../../shared/types/user";
 import { useUserService } from "../../components/providers/User";
 
-export function Email({ user }: { user: IUser }) {
+export function Email({ user, onUpdate }: { user: IUser, onUpdate: () => void }) {
     const userService = useUserService();
     const [showDropdown, setShowDropDown] = useState<boolean>(false);
     const [input, setInput] = useState<string>('');
@@ -31,6 +31,7 @@ export function Email({ user }: { user: IUser }) {
         try {
             await userService.setEmail(input)
             handleDropdown();
+            onUpdate();
             alert("Email changed!");
         } catch (error) {
             console.error("Error changing Email:", error);

--- a/src/frontend/src/features/profile/ProfileProperties.tsx
+++ b/src/frontend/src/features/profile/ProfileProperties.tsx
@@ -15,17 +15,18 @@ export function ProfilePropertiesPrimary() {
     const [error, setError] = useState<boolean>(false);
     const [user, setUser] = useState<IUser>(DEFAULT_USER);
 
-    useEffect(() => {
-        async function getUser() {
-            try {
-                const result = await userService.getUser();
-                setUser(result.data);
-            } catch (e: any) {
-                setError(true);
-            } finally {
-                setLoading(false);
-            }
+    async function getUser() {
+        try {
+            const result = await userService.getUser();
+            setUser(result.data);
+        } catch (e: any) {
+            setError(true);
+        } finally {
+            setLoading(false);
         }
+    }
+
+    useEffect(() => {
         getUser();
     }, [])
 
@@ -43,8 +44,8 @@ export function ProfilePropertiesPrimary() {
     return (
         <ProfilePropertiesPrimaryContainer>
             <ProfileRelationships />
-            <Username user={user} />
-            <Email user={user} />
+            <Username user={user} onUpdate={getUser} />
+            <Email user={user} onUpdate={getUser} />
             <Password />
             <TwoFactor />
             <DeleteUser />

--- a/src/frontend/src/features/profile/Username.tsx
+++ b/src/frontend/src/features/profile/Username.tsx
@@ -4,7 +4,7 @@ import { SubmitPropertyChange } from "./Submit";
 import { IUser } from "../../shared/types/user";
 import { useUserService } from "../../components/providers/User";
 
-export function Username({ user }: { user: IUser }) {
+export function Username({ user, onUpdate }: { user: IUser, onUpdate: () => void }) {
     const userService = useUserService();
     const [showDropdown, setShowDropDown] = useState<boolean>(false);
     const [input, setInput] = useState<string>('');
@@ -31,6 +31,7 @@ export function Username({ user }: { user: IUser }) {
         try {
             await userService.setUsername(input)
             handleDropdown();
+            onUpdate();
             alert("Username changed!");
         } catch (error) {
             console.error("Error changing Username:", error);

--- a/src/frontend/src/features/relationships/FriendshipList.tsx
+++ b/src/frontend/src/features/relationships/FriendshipList.tsx
@@ -35,8 +35,8 @@ export function FriendshipList({ friends, onRefresh }: { friends: IFriendship[],
             const listItems = list.map((item: IFriendship) =>
                 <li key={item.id}>
                     <div className='flex justify-between' id={item.userName + '-container'}>
-                        <button onClick={() => navigate('/profile/' + item.userId)}>
-                            {item.userName}
+                        <button onClick={() => navigate('/profile/' + item.userId)} className="flex items-center gap-2">
+                            {item.activityStatus === 'ONLINE' ? '🟢' : '🔴'} {item.userName}
                         </button>
                         <button onClick={() => removeFriend(item.id)} className="bg-red-500">remove</button>
                     </div>

--- a/src/frontend/src/shared/types/friendship.ts
+++ b/src/frontend/src/shared/types/friendship.ts
@@ -8,6 +8,7 @@ export interface IFriendship {
   // The other user in the relationship
   userId: number;
   userName: string;
+  activityStatus: string;
   // True if current user sent the request / is the blocker
   isRequester: boolean;
 }
@@ -57,13 +58,15 @@ export function responseToFriendship(
   currentUserId: number
 ): IFriendship {
   const isRequester = currentUserId === response.requester_id;
+  const otherUser = isRequester ? response.addressee : response.requester;
   return {
     created_at: response.created_at,
     id: response.id,
     status: response.status,
     updated_at: response.updated_at,
     userId: isRequester ? response.addressee_id : response.requester_id,
-    userName: isRequester ? response.addressee.name : response.requester.name,
+    userName: otherUser.name,
+    activityStatus: otherUser.activity_status ?? 'OFFLINE',
     isRequester
   };
 }

--- a/src/frontend/src/shared/types/user.ts
+++ b/src/frontend/src/shared/types/user.ts
@@ -10,6 +10,7 @@ export interface IUser {
   id: number;
   email: string;
   name: string;
+  activity_status?: string;
 }
 
 export interface IGetUser {


### PR DESCRIPTION
This diff fixes a number of small issues:
- when user deletes themselves they could still do actions in the app, this updates to kick them back to login screen
- 2fa issuer changed to Transcendence rather than Auth service #198 
- update of username and email now automatically shows updated info rather than needing a manual reload
- added online status for friends in the relationship page
- fix infite refresh loop for auto-login