### PR TITLE
remove axios response interceptor

### DIFF
--- a/src/frontend/src/components/providers/Auth.tsx
+++ b/src/frontend/src/components/providers/Auth.tsx
@@ -152,27 +152,6 @@ export function AuthProvider({ children }: { children: ReactNode }): JSX.Element
         };
     }, [token]);
 
-    useLayoutEffect(() => {
-        const refreshIntercept = api.interceptors.response.use((config) => {
-            return config;
-        }, async (error) => {
-            if (error.response?.status === 401) {
-                if (retry) {
-                    setRetry(false);
-                    return Promise.reject(error);
-                }
-                setRetry(true);
-                refresh();
-                return api(error.config);
-            }
-            return Promise.reject(error);
-        });
-
-        return function cleanup() {
-            api.interceptors.request.eject(refreshIntercept);
-        };
-    }, [token]);
-
     function failedAuthentication() {
         setIsAuthenticated(false);
         setIsLoading(false);


### PR DESCRIPTION
This PR removes the axios response interceptor because it was causing the frontend to end in an endless loop with auto-login