### PR TITLE
Error handling update

### DIFF
--- a/src/auth/src/client/user-management.ts
+++ b/src/auth/src/client/user-management.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { UserManagementService, ActivityStatus } from '../types/user-management-service.js';
+import { ResourceConflictError } from '../error/auth.js';
 
 interface CreateUserResponse {
   user_id: number;
@@ -45,6 +46,10 @@ export class UserManagementClient implements UserManagementService {
       return response.data.user_id;
     } catch (error) {
       if (axios.isAxiosError(error) && error.response) {
+        if (error.response.status === 409) {
+          const errorData = error.response.data as ErrorResponse;
+          throw new ResourceConflictError(errorData.message || 'User already exists');
+        }
         const errorData = error.response.data as ErrorResponse;
         throw new Error(errorData.message || 'Failed to create user');
       }

--- a/src/frontend/src/app/App.tsx
+++ b/src/frontend/src/app/App.tsx
@@ -11,6 +11,7 @@ import { Tournament } from '../pages/Tournament.tsx';
 import { VisitorProfile } from '../pages/VisitorProfile.tsx';
 import { Relationships } from '../pages/Relationships.tsx';
 import { GeneralErrorFallback } from '../features/errors/GeneralErrorFallBack.tsx';
+import { FeatureErrorFallback } from '../features/errors/FeatureErrorFallback.tsx';
 import { GAME_NAVIGATION, ENTRY_PAGE, REGISTER_PAGE, LOGIN_PAGE, START_MENU_PAGE, CREDITS_PAGE, HOME_PAGE, PROFILE_PAGE, USER_PAGE, RELATIONSHIPS_PAGE, VISITOR_PAGE, TOURNAMENT_BASE, TOURNAMENT_PAGE, TWO_FACTOR_PAGE, TOURNAMENT_CREATION_PAGE } from '../shared/constants/navigation.ts';
 import { Entry } from '../pages/Entry.tsx';
 import { Register } from '../pages/Register.tsx';
@@ -58,15 +59,15 @@ export function App() {
                                     </Route>
                                     <Route path={CREDITS_PAGE} element={<Credits />} />
                                     <Route element={<PrivateRoutes />}>
-                                        <Route path={HOME_PAGE} element={<Home />} />
+                                        <Route path={HOME_PAGE} element={<ErrorBoundary FallbackComponent={FeatureErrorFallback}><Home /></ErrorBoundary>} />
                                         <Route path={PROFILE_PAGE} >
-                                            <Route path={USER_PAGE} element={<Profile />} />
-                                            <Route path={USER_PAGE + '/' + RELATIONSHIPS_PAGE} element={<Relationships />} />
-                                            <Route path={VISITOR_PAGE} element={<VisitorProfile />} />
+                                            <Route path={USER_PAGE} element={<ErrorBoundary FallbackComponent={FeatureErrorFallback}><Profile /></ErrorBoundary>} />
+                                            <Route path={USER_PAGE + '/' + RELATIONSHIPS_PAGE} element={<ErrorBoundary FallbackComponent={FeatureErrorFallback}><Relationships /></ErrorBoundary>} />
+                                            <Route path={VISITOR_PAGE} element={<ErrorBoundary FallbackComponent={FeatureErrorFallback}><VisitorProfile /></ErrorBoundary>} />
                                         </Route >
                                         <Route path={TOURNAMENT_BASE} >
-                                            <Route path={TOURNAMENT_PAGE} element={<Tournament />} />
-                                            <Route path={TOURNAMENT_CREATION_PAGE} element={<TournamentCreation />} />
+                                            <Route path={TOURNAMENT_PAGE} element={<ErrorBoundary FallbackComponent={FeatureErrorFallback}><Tournament /></ErrorBoundary>} />
+                                            <Route path={TOURNAMENT_CREATION_PAGE} element={<ErrorBoundary FallbackComponent={FeatureErrorFallback}><TournamentCreation /></ErrorBoundary>} />
                                         </Route  >
                                         <Route path={GAME_NAVIGATION} element={<Game />} />
                                     </Route>

--- a/src/frontend/src/components/providers/Auth.tsx
+++ b/src/frontend/src/components/providers/Auth.tsx
@@ -62,7 +62,6 @@ export function AuthProvider({ children }: { children: ReactNode }): JSX.Element
             console.error(e)
             setToken(failedToken);
             throw e
-            // TODO: error handling
         }
     }
 

--- a/src/frontend/src/features/entry/LoginForm.tsx
+++ b/src/frontend/src/features/entry/LoginForm.tsx
@@ -1,29 +1,27 @@
-import { JSX } from "react"
+import { JSX, useState } from "react"
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../../components/providers/Auth.tsx";
 import { ENTRY_NAVIGATION, HOME_NAVIGATION, TWO_FACTOR_NAVIGATION } from "../../shared/constants/navigation.ts";
+import { extractApiError } from "../../shared/utils/error.ts";
 
 /* v8 ignore start */
 
 export function LoginForm(): JSX.Element {
     const auth = useAuth();
     const navigate = useNavigate();
+    const [errorMessage, setErrorMessage] = useState<string>('');
 
     async function submit(form: FormData) {
+        setErrorMessage('');
         const email = form.get("email") as string;
-        const user_name = form.get("username") as string;
         const password = form.get("password") as string;
 
-        if (email === null) {
-            alert('non-valid email')
+        if (!email) {
+            setErrorMessage('Email is required.');
             return;
         }
-        if (user_name === null) {
-            alert('non-valid username')
-            return;
-        }
-        if (password === null) {
-            alert('non-valid password')
+        if (!password) {
+            setErrorMessage('Password is required.');
             return;
         }
 
@@ -32,23 +30,25 @@ export function LoginForm(): JSX.Element {
             navigate(HOME_NAVIGATION);
         } catch (e: any) {
             if (e.response?.status === 420) {
-                navigate(TWO_FACTOR_NAVIGATION, { state: { email, password } })
+                navigate(TWO_FACTOR_NAVIGATION, { state: { email, password } });
             } else {
-                alert('log in failed')
+                setErrorMessage(extractApiError(e));
                 console.error(e);
             }
         }
     };
+
     return (
         <div id="login-form">
             <form action={submit}>
                 <label htmlFor="email">email</label><br />
                 <input type="text" name="email" className="border" /> <br />
-                <label htmlFor="username">username</label><br />
-                <input type="text" name="username" className="border" /> <br />
                 <label htmlFor="password">password</label><br />
-                <input type="text" name="password" className="border" /> <br /><br />
-                <button type="submit" className="border w-1/4" > LOG IN</button>
+                <input type="password" name="password" className="border" /> <br /><br />
+                {errorMessage && (
+                    <p className="text-red-400 mb-2">{errorMessage}</p>
+                )}
+                <button type="submit" className="border w-1/4">LOG IN</button>
             </form>
             <button onClick={() => navigate(ENTRY_NAVIGATION)} className="m-10">GO BACK</button>
         </div>

--- a/src/frontend/src/features/entry/RegisterForm.tsx
+++ b/src/frontend/src/features/entry/RegisterForm.tsx
@@ -2,23 +2,49 @@ import { JSX, useState } from "react"
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../../components/providers/Auth.tsx";
 import { ENTRY_NAVIGATION, LOGIN_NAVIGATION } from "../../shared/constants/navigation.ts";
+import { extractApiError } from "../../shared/utils/error.ts";
+
+function validateFields(email: string, user_name: string, password: string): string {
+    if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email))
+        return 'Please enter a valid email address.';
+    if (!user_name)
+        return 'Username is required.';
+    if (user_name.length < 3 || user_name.length > 20)
+        return 'Username must be between 3 and 20 characters.';
+    if (!/^[a-zA-Z0-9_]+$/.test(user_name))
+        return 'Username may only contain letters, numbers, and underscores.';
+    if (!password)
+        return 'Password is required.';
+    if (password.length < 8)
+        return 'Password must be at least 8 characters.';
+    if (!/[A-Z]/.test(password))
+        return 'Password must contain at least one uppercase letter.';
+    if (!/[a-z]/.test(password))
+        return 'Password must contain at least one lowercase letter.';
+    if (!/[0-9]/.test(password))
+        return 'Password must contain at least one number.';
+    if (!/[!@#$%^&*(),.?":{}|<>]/.test(password))
+        return 'Password must contain at least one special character (!@#$%^&*(),.?":{}|<>).';
+    if (/\s/.test(password))
+        return 'Password must not contain spaces.';
+    return '';
+}
 
 export function RegisterForm(): JSX.Element {
     const auth = useAuth();
     const navigate = useNavigate();
     const [registered, setRegistered] = useState<boolean>(false);
+    const [errorMessage, setErrorMessage] = useState<string>('');
 
     async function submit(form: FormData) {
+        setErrorMessage('');
         const email = form.get("email") as string;
         const user_name = form.get("username") as string;
         const password = form.get("password") as string;
 
-        if (user_name === null) {
-            alert('non-valid user-name')
-            return;
-        }
-        if (password === null) {
-            alert('non-valid password')
+        const validationError = validateFields(email, user_name, password);
+        if (validationError) {
+            setErrorMessage(validationError);
             return;
         }
 
@@ -26,9 +52,10 @@ export function RegisterForm(): JSX.Element {
             await auth.register({ email, user_name, password });
             setRegistered(true);
         } catch (e: any) {
-            alert('registration failed');
+            setErrorMessage(extractApiError(e));
         }
     };
+
     return (
         <div id="registration-container">
             {!registered ?
@@ -39,8 +66,15 @@ export function RegisterForm(): JSX.Element {
                         <label htmlFor="username">username</label><br />
                         <input type="text" name="username" className="border" /> <br />
                         <label htmlFor="password">password</label><br />
-                        <input type="text" name="password" className="border" /> <br /><br />
-                        <button type="submit" className="border w-1/4" >REGISTER</button>
+                        <input type="password" name="password" className="border" /> <br />
+                        <small className="text-gray-400">
+                            Min 8 chars · uppercase · lowercase · number · special char (!@#$%^&amp;*(),.?&quot;:&#123;&#125;|&lt;&gt;)
+                        </small>
+                        <br /><br />
+                        {errorMessage && (
+                            <p className="text-red-400 mb-2">{errorMessage}</p>
+                        )}
+                        <button type="submit" className="border w-1/4">REGISTER</button>
                     </form>
                     <button onClick={() => navigate(ENTRY_NAVIGATION)} className="m-10">GO BACK</button>
                 </div> :

--- a/src/frontend/src/features/errors/FeatureErrorFallback.tsx
+++ b/src/frontend/src/features/errors/FeatureErrorFallback.tsx
@@ -1,0 +1,12 @@
+import { JSX } from "react";
+import { IFallbackErrorProps } from "../../shared/types/types";
+
+export function FeatureErrorFallback({ error, resetErrorBoundary }: IFallbackErrorProps): JSX.Element {
+    return (
+        <div role="alert" className="p-4 text-center">
+            <p>Something went wrong in this section.</p>
+            <pre className="text-sm mt-2 mb-4">{error?.message}</pre>
+            <button onClick={resetErrorBoundary}>Retry</button>
+        </div>
+    );
+}

--- a/src/frontend/src/features/errors/FeatureErrorFallback.tsx
+++ b/src/frontend/src/features/errors/FeatureErrorFallback.tsx
@@ -2,10 +2,10 @@ import { JSX } from "react";
 import { IFallbackErrorProps } from "../../shared/types/types";
 
 export function FeatureErrorFallback({ error, resetErrorBoundary }: IFallbackErrorProps): JSX.Element {
+    console.error('[FeatureErrorFallback]', error);
     return (
         <div role="alert" className="p-4 text-center">
             <p>Something went wrong in this section.</p>
-            <pre className="text-sm mt-2 mb-4">{error?.message}</pre>
             <button onClick={resetErrorBoundary}>Retry</button>
         </div>
     );

--- a/src/frontend/src/features/errors/GeneralErrorFallBack.tsx
+++ b/src/frontend/src/features/errors/GeneralErrorFallBack.tsx
@@ -3,10 +3,10 @@ import { IFallbackErrorProps } from "../../shared/types/types";
 
 
 export function GeneralErrorFallback({ error, resetErrorBoundary }: IFallbackErrorProps): JSX.Element {
+    console.error('[GeneralErrorFallback]', error);
     return (
         <div role="alert">
-            <p>Oops! Something went wrong:</p>
-            <pre >{error.message}</pre>
+            <p>Oops! Something went wrong.</p>
             <button onClick={resetErrorBoundary}>Try again</button>
         </div>
     );

--- a/src/frontend/src/features/live-chat/LiveChatUsers.tsx
+++ b/src/frontend/src/features/live-chat/LiveChatUsers.tsx
@@ -46,7 +46,7 @@ export function UserSearchBar({ setProfile }: { setProfile: Dispatch<SetStateAct
             const result = await service.getUserByName(user);
             setProfile(result);
         } catch (e: any) {
-            if (e.response.status === 404) {
+            if (e.response?.status === 404) {
                 alert('no user found')
                 return;
             }

--- a/src/frontend/src/features/profile/Email.tsx
+++ b/src/frontend/src/features/profile/Email.tsx
@@ -3,6 +3,7 @@ import { DisplayedProfileProperty } from "./ProfileProperty";
 import { SubmitPropertyChange } from "./Submit";
 import { IUser } from "../../shared/types/user";
 import { useUserService } from "../../components/providers/User";
+import { extractApiError } from "../../shared/utils/error";
 
 export function Email({ user, onUpdate }: { user: IUser, onUpdate: () => void }) {
     const userService = useUserService();
@@ -35,7 +36,7 @@ export function Email({ user, onUpdate }: { user: IUser, onUpdate: () => void })
             alert("Email changed!");
         } catch (error) {
             console.error("Error changing Email:", error);
-            alert("Email change failed");
+            alert(`Email change failed: ${extractApiError(error)}`);
         }
     }
     return (

--- a/src/frontend/src/features/profile/Password.tsx
+++ b/src/frontend/src/features/profile/Password.tsx
@@ -2,6 +2,7 @@ import { BaseSyntheticEvent, useState } from "react";
 import { SubmitPropertyChangeOldNew } from "./Submit";
 import { HiddenProfileProperty } from "./ProfileProperty";
 import { useAuth } from "../../components/providers/Auth";
+import { extractApiError } from "../../shared/utils/error";
 
 export function Password() {
     const auth = useAuth();
@@ -43,7 +44,7 @@ export function Password() {
             alert("Password changed!");
         } catch (error) {
             console.error("Error changing Password:", error);
-            alert("Password change failed");
+            alert(`Password change failed: ${extractApiError(error)}`);
         }
     }
     return (

--- a/src/frontend/src/features/profile/Username.tsx
+++ b/src/frontend/src/features/profile/Username.tsx
@@ -3,6 +3,7 @@ import { DisplayedProfileProperty } from "./ProfileProperty";
 import { SubmitPropertyChange } from "./Submit";
 import { IUser } from "../../shared/types/user";
 import { useUserService } from "../../components/providers/User";
+import { extractApiError } from "../../shared/utils/error";
 
 export function Username({ user, onUpdate }: { user: IUser, onUpdate: () => void }) {
     const userService = useUserService();
@@ -35,7 +36,7 @@ export function Username({ user, onUpdate }: { user: IUser, onUpdate: () => void
             alert("Username changed!");
         } catch (error) {
             console.error("Error changing Username:", error);
-            alert("Username change failed");
+            alert(`Username change failed: ${extractApiError(error)}`);
         }
     }
     return (

--- a/src/frontend/src/shared/utils/error.ts
+++ b/src/frontend/src/shared/utils/error.ts
@@ -7,22 +7,22 @@
  *   3. `message` string (domain / auth errors): returns as-is.
  */
 export function extractApiError(e: unknown): string {
-    if (!e || typeof e !== 'object') return 'An unexpected error occurred';
-    const err = e as any;
-    const data = err?.response?.data;
-    if (!data) return err?.message || 'An unexpected error occurred';
+  if (!e || typeof e !== 'object') return 'An unexpected error occurred';
+  const err = e as any;
+  const data = err?.response?.data;
+  if (!data) return err?.message || 'An unexpected error occurred';
 
-    if (Array.isArray(data.details) && data.details.length > 0) {
-        return data.details
-            .map((d: any) => d.message as string)
-            .filter(Boolean)
-            .join('; ');
-    }
-    if (Array.isArray(data.message) && data.message.length > 0) {
-        return (data.message as string[]).join('; ');
-    }
-    if (typeof data.message === 'string' && data.message) {
-        return data.message;
-    }
-    return err?.message || 'An unexpected error occurred';
+  if (Array.isArray(data.details) && data.details.length > 0) {
+    return data.details
+      .map((d: any) => d.message as string)
+      .filter(Boolean)
+      .join('; ');
+  }
+  if (Array.isArray(data.message) && data.message.length > 0) {
+    return (data.message as string[]).join('; ');
+  }
+  if (typeof data.message === 'string' && data.message) {
+    return data.message;
+  }
+  return err?.message || 'An unexpected error occurred';
 }

--- a/src/frontend/src/shared/utils/error.ts
+++ b/src/frontend/src/shared/utils/error.ts
@@ -1,0 +1,28 @@
+/**
+ * Extracts a human-readable error message from an axios response error.
+ *
+ * Handles the three message shapes produced by the backend:
+ *   1. `details` array (Fastify schema-validation errors): joins each detail's message.
+ *   2. `message` array (password-rule errors): joins the array items.
+ *   3. `message` string (domain / auth errors): returns as-is.
+ */
+export function extractApiError(e: unknown): string {
+    if (!e || typeof e !== 'object') return 'An unexpected error occurred';
+    const err = e as any;
+    const data = err?.response?.data;
+    if (!data) return err?.message || 'An unexpected error occurred';
+
+    if (Array.isArray(data.details) && data.details.length > 0) {
+        return data.details
+            .map((d: any) => d.message as string)
+            .filter(Boolean)
+            .join('; ');
+    }
+    if (Array.isArray(data.message) && data.message.length > 0) {
+        return (data.message as string[]).join('; ');
+    }
+    if (typeof data.message === 'string' && data.message) {
+        return data.message;
+    }
+    return err?.message || 'An unexpected error occurred';
+}

--- a/src/user-management/src/client/api-gateway.ts
+++ b/src/user-management/src/client/api-gateway.ts
@@ -18,7 +18,7 @@ export class ApiGatewayClient{
   async notifyUsers(userIds: number[], event: WebSocketEvent): Promise<void> {
     try {
       await axios.post(`${this.baseUrl}/internal/ws/notify`, {
-        userIds,
+        userIds: userIds.map(String),
         event
       }, {
         timeout: this.timeout,

--- a/src/user-management/src/client/api-gateway.ts
+++ b/src/user-management/src/client/api-gateway.ts
@@ -1,5 +1,8 @@
 import axios from 'axios';
-// import { ClientError } from '../error/user-management.js';
+import pino from 'pino';
+import { loggerOptions } from '../config/logger.js';
+
+const logger = pino(loggerOptions);
 
 export interface WebSocketEvent {
   type: string;
@@ -23,9 +26,8 @@ export class ApiGatewayClient{
           'Content-Type': 'application/json'
         }
       });
-    } catch {
-      // throw new ClientError('APIGatewayClient');
-      
+    } catch (err) {
+      logger.error({ err }, '[ApiGatewayClient] notifyUsers failed (non-fatal)');
     }
   }
 


### PR DESCRIPTION
This diff fixes a number of error handling issues:
- removed username field from the login form as authentication login request payload required only email and password, and username is only used for the frontend validation. what was happening the auth services would issue a token and cookie when user enters the right email and password, but frontend will silently discard a token if username is mismatched, while keeping the cookie showing that the user is actually online and logged as session considered to be active. 
- added frontend validation for the registration so that user can see if they use expected email, username and password rules, so user know what went wrong instead of generic log in/register failed alerts. added hint for password creation #169 #188 
- fixed gateway client thrown error and instead fail open on it with logging on error #176 
- added feature fallback error in frontend