### PR TITLE
fix chat mark messages as read

### DIFF
--- a/src/frontend/src/features/live-chat/Chat.tsx
+++ b/src/frontend/src/features/live-chat/Chat.tsx
@@ -20,6 +20,9 @@ export function Chat({ channelId, messageUpdate }: { channelId: string, messageU
                     setError(false)
                     const result = await service.getChannelMessages(channelId);
                     setChat([...result].reverse());
+                    service.markChannelRead(channelId).catch((e: any) => {
+                        console.error("Failed to mark channel as read:", e);
+                    });
                 } catch (e: any) {
                     console.error(e);
                     setError(e);


### PR DESCRIPTION
fixes that chat read count does not get update when user has chat open and a message is received